### PR TITLE
make sure fixtures aren't cached in browser cache

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -74,6 +74,7 @@ jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function(url) {
   var self = this;
   $.ajax({
     async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+    cache: false,
     dataType: 'html',
     url: url,
     success: function(data) {


### PR DESCRIPTION
As in the title - I spent half an hour wondering why my tests don't work, turns out they were loading an old version of the fixtures, even after restarting the server...
