### PR TITLE
toHaveText can now accept a regex

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,6 +29,8 @@ jasmine-jquery provides following custom matchers (in alphabetical order):
 - `toExist()`
 - `toHaveAttr(attributeName, attributeValue)`
   - attribute value is optional, if omitted it will check only if attribute exists
+- `toHaveBeenTriggeredOn(selector)`
+  - if event has been triggered on `selector` (see "Event Spies", below)
 - `toHaveClass(className)`
   - e.g. `expect($('<div class="some-class"></div>')).toHaveClass("some-class")`  
 - `toHaveData(key, value)`
@@ -129,6 +131,18 @@ Additionally, two clean up methods are provided:
   - cleans-up fixtures container (this is done automatically between tests by Fixtures module, so there is no need to ever invoke this manually, unless you're testing a really fancy special case and need to clean-up fixtures in the middle of your test)
   
 These two methods do not have global short cut functions.
+
+## Event Spies
+
+Spying on jQuery events can be done with `spyOnEvent` and
+`assert(eventName).toHaveBeenTriggeredOn(selector)`. First, spy on the event:
+
+    spyOnEvent($('#some_element'), 'click');
+    $('#some_element').click();
+    expect('click').toHaveBeenTriggeredOn($('#some_element'));
+
+Much thanks to Luiz Fernando Ribeiro for his
+[article on Jasmine event spies](http://luizfar.wordpress.com/2011/01/10/testing-events-on-jquery-objects-with-jasmine/).
 
 ## Supported browsers and jQuery versions
 

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -14,6 +14,10 @@ var sandbox = function(attributes) {
   return jasmine.getFixtures().sandbox(attributes);
 };
 
+var spyOnEvent = function(selector, eventName) {
+  jasmine.JQuery.events.spyOn(selector, eventName);
+}
+
 jasmine.getFixtures = function() {
   return jasmine.currentFixtures_ = jasmine.currentFixtures_ || new jasmine.Fixtures();
 };
@@ -102,6 +106,31 @@ jasmine.JQuery.elementToString = function(element) {
 
 jasmine.JQuery.matchersClass = {};
 
+(function(namespace) {
+  var data = {
+    spiedEvents: {},
+    handlers:    []
+  };
+
+  namespace.events = {
+    spyOn: function(selector, eventName) {
+      var handler = function(e) {
+        data.spiedEvents[[selector, eventName]] = e;
+      };
+      $(selector).bind(eventName, handler);
+      data.handlers.push(handler);
+    },
+
+    wasTriggered: function(selector, eventName) {
+      return !!(data.spiedEvents[[selector, eventName]]);
+    },
+
+    cleanUp: function() {
+      data.spiedEvents = {};
+      data.handlers    = [];
+    }
+  }
+})(jasmine.JQuery);
 
 (function(){
   var jQueryMatchers = {
@@ -202,8 +231,20 @@ jasmine.JQuery.matchersClass = {};
 
 beforeEach(function() {
   this.addMatchers(jasmine.JQuery.matchersClass);
+  this.addMatchers({
+    toHaveBeenTriggeredOn: function(selector) {
+      this.message = function() {
+        return [
+          "Expected event " + this.actual + " to have been triggered on" + selector,
+          "Expected event " + this.actual + " not to have been triggered on" + selector
+        ];
+      };
+      return jasmine.JQuery.events.wasTriggered(selector, this.actual);
+    }
+  })
 });
 
 afterEach(function() {
   jasmine.getFixtures().cleanUp();
+  jasmine.JQuery.events.cleanUp();
 });

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -535,4 +535,25 @@ describe("jQuery matchers", function() {
       expect($('#sandbox')).not.toContain('div');
     });
   });
+
+  describe('toHaveBeenTriggeredOn', function() {
+    beforeEach(function() {
+      setFixtures(sandbox().html('<a id="clickme">Click Me</a> <a id="otherlink">Other Link</a>'));
+      spyOnEvent($('#clickme'), 'click');
+    });
+
+    it('should pass if the event was triggered on the object', function() {
+      $('#clickme').click();
+      expect('click').toHaveBeenTriggeredOn($('#clickme'));
+    });
+
+    it('should pass negated if the event was never triggered', function() {
+      expect('click').not.toHaveBeenTriggeredOn($('#clickme'));
+    });
+
+    it('should pass negated if the event was triggered on another non-descendant object', function() {
+      $('#otherlink').click();
+      expect('click').not.toHaveBeenTriggeredOn($('#clickme'));
+    });
+  });
 });


### PR DESCRIPTION
e.g. `expect($('#foo')).toHaveText(/bar/);
