### PR TITLE
jQuery.noConflict fixes

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -54,18 +54,18 @@ jasmine.Fixtures.prototype.clearCache = function() {
 };
 
 jasmine.Fixtures.prototype.cleanUp = function() {
-  $('#' + this.containerId).remove();
+  jQuery('#' + this.containerId).remove();
 };
 
 jasmine.Fixtures.prototype.sandbox = function(attributes) {
   var attributesToSet = attributes || {};
-  return $('<div id="sandbox" />').attr(attributesToSet);
+  return jQuery('<div id="sandbox" />').attr(attributesToSet);
 };
 
 jasmine.Fixtures.prototype.createContainer_ = function(html) {
-  var container = $('<div id="' + this.containerId + '" />');
+  var container = jQuery('<div id="' + this.containerId + '" />');
   container.html(html);
-  $('body').append(container);
+  jQuery('body').append(container);
 };
 
 jasmine.Fixtures.prototype.getFixtureHtml_ = function(url) {  
@@ -78,7 +78,7 @@ jasmine.Fixtures.prototype.getFixtureHtml_ = function(url) {
 jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function(relativeUrl) {
   var self = this;
   var url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl;
-  $.ajax({
+  jQuery.ajax({
     async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
     cache: false,
     dataType: 'html',
@@ -97,11 +97,11 @@ jasmine.Fixtures.prototype.proxyCallTo_ = function(methodName, passedArguments) 
 jasmine.JQuery = function() {};
 
 jasmine.JQuery.browserTagCaseIndependentHtml = function(html) {
-  return $('<div/>').append(html).html();
+  return jQuery('<div/>').append(html).html();
 };
 
 jasmine.JQuery.elementToString = function(element) {
-  return $('<div />').append(element.clone()).html();
+  return jQuery('<div />').append(element.clone()).html();
 };
 
 jasmine.JQuery.matchersClass = {};
@@ -117,7 +117,7 @@ jasmine.JQuery.matchersClass = {};
       var handler = function(e) {
         data.spiedEvents[[selector, eventName]] = e;
       };
-      $(selector).bind(eventName, handler);
+      jQuery(selector).bind(eventName, handler);
       data.handlers.push(handler);
     },
 


### PR DESCRIPTION
Hi,

I made a simple fix to prefer jQuery instead of $, just in case the user is using jQuery.noConflict().

I was unable to get your test suite working (either with our without my patch), so you should test with your suite after applying the patch.  Either way, the patch is pretty trivial.
