### PR TITLE
Added new matcher to spyOnEvent: toHaveBeenPreventedOn

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,8 @@ jasmine-jquery provides following custom matchers (in alphabetical order):
   - attribute value is optional, if omitted it will check only if attribute exists
 - `toHaveBeenTriggeredOn(selector)`
   - if event has been triggered on `selector` (see "Event Spies", below)
+- `toHaveBeenPreventedOn(selector)`
+  - if event has been prevented on `selector` (see "Event Spies", below)
 - `toHaveClass(className)`
   - e.g. `expect($('<div class="some-class"></div>')).toHaveClass("some-class")`  
 - `toHaveData(key, value)`
@@ -152,6 +154,12 @@ Spying on jQuery events can be done with `spyOnEvent` and
     spyOnEvent($('#some_element'), 'click');
     $('#some_element').click();
     expect('click').toHaveBeenTriggeredOn($('#some_element'));
+
+You can similarly check if triggered event was prevented:
+
+    spyOnEvent($('#some_element'), 'click');
+    $('#some_element').click();
+    expect('click').toHaveBeenPreventedOn($('#some_element'));
 
 Much thanks to Luiz Fernando Ribeiro for his
 [article on Jasmine event spies](http://luizfar.wordpress.com/2011/01/10/testing-events-on-jquery-objects-with-jasmine/).

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -141,6 +141,10 @@ jasmine.JQuery.matchersClass = {};
       return !!(data.spiedEvents[[selector, eventName]]);
     },
 
+    wasPrevented: function(selector, eventName) {
+      return data.spiedEvents[[selector, eventName]].isDefaultPrevented();
+    },
+
     cleanUp: function() {
       data.spiedEvents = {};
       data.handlers    = [];
@@ -279,7 +283,18 @@ beforeEach(function() {
       };
       return jasmine.JQuery.events.wasTriggered(selector, this.actual);
     }
-  })
+  });
+  this.addMatchers({
+    toHaveBeenPreventedOn: function(selector) {
+      this.message = function() {
+        return [
+          "Expected event " + this.actual + " to have been prevented on" + selector,
+          "Expected event " + this.actual + " not to have been prevented on " + selector
+        ];
+      };
+      return jasmine.JQuery.events.wasPrevented(selector, this.actual);
+    }
+  });
 });
 
 afterEach(function() {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -643,6 +643,34 @@ describe("jQuery matchers", function() {
     });
   });
   
+  describe('toHaveBeenPreventedOn', function() {
+    beforeEach(function() {
+      setFixtures(sandbox().html('<a id="clickme">Click Me</a> <a id="otherlink">Other Link</a>'));
+      spyOnEvent($('#clickme'), 'click');
+    });
+
+    it('should pass if the event was prevented on the object', function() {
+      $('#clickme').bind('click', function(event) {
+        event.preventDefault();
+      });
+      $('#clickme').click();
+      expect('click').toHaveBeenPreventedOn($('#clickme'));
+    });
+
+    it('should pass negated if the event was never prevented', function() {
+      $('#clickme').click();
+      expect('click').not.toHaveBeenPreventedOn($('#clickme'));
+    });
+
+    it('should pass negated if the event was prevented on another non-descendant object', function() {
+      $('#otherlink').bind('click', function(event) {
+        event.preventDefault();
+      });
+      $('#clickme').click();
+      expect('click').not.toHaveBeenPreventedOn($('#clickme'));
+    });
+  });
+
   describe('toHandle', function() {
     beforeEach(function() {
       setFixtures(sandbox().html('<a id="clickme">Click Me</a> <a id="otherlink">Other Link</a>'));


### PR DESCRIPTION
I were looking for a way to test if my event preventing works but simple:

```
it("prevents event", function() {
  $("#element").pluginWithPrevent();
  $("#element").bind("click", function(event) {
    expect(event.isDefaultPrevented()).toBe(true);
  });
  $("#element").click();
});
```

But for couple of reasons that doesn't work. So I tried to add matcher `toHaveBeenPreventedOn`, similar to `toHaveBeenTriggeredOn`, and it works for me.
