### PR TITLE
Improve readability of event messages

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -279,8 +279,8 @@ beforeEach(function() {
     toHaveBeenTriggeredOn: function(selector) {
       this.message = function() {
         return [
-          "Expected event " + this.actual + " to have been triggered on" + selector,
-          "Expected event " + this.actual + " not to have been triggered on" + selector
+          "Expected event " + this.actual + " to have been triggered on " + selector,
+          "Expected event " + this.actual + " not to have been triggered on " + selector
         ];
       };
       return jasmine.JQuery.events.wasTriggered($(selector), this.actual);
@@ -290,7 +290,7 @@ beforeEach(function() {
     toHaveBeenPreventedOn: function(selector) {
       this.message = function() {
         return [
-          "Expected event " + this.actual + " to have been prevented on" + selector,
+          "Expected event " + this.actual + " to have been prevented on " + selector,
           "Expected event " + this.actual + " not to have been prevented on " + selector
         ];
       };


### PR DESCRIPTION
A small change, just as the the title says increases readability of the test by adding space between the message and selector.

Also I saw your message on finding a maintainer and I outlined here in an issue I created earlier about my interest: https://github.com/velesin/jasmine-jquery/issues/52

Thanks,

Travis
