### PR TITLE
expect('#selector.without_$').toJustWork() -- revised

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -250,7 +250,12 @@ jasmine.JQuery.matchersClass = {};
   var bindMatcher = function(methodName) {
     var builtInMatcher = jasmine.Matchers.prototype[methodName];
 
+
     jasmine.JQuery.matchersClass[methodName] = function() {
+      if (typeof this.actual === 'string' && !builtInMatcher) {
+        this.actual = $(this.actual);
+      }
+
       if (this.actual
           && (this.actual instanceof jQuery
              || jasmine.isDomNode(this.actual))) {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -823,5 +823,31 @@ describe("jQuery matchers", function() {
     });
 
   });
+
+  describe("when a string is passed, it should be treated as a jQuery selector and ", function () {
+    var className = "some-class";
+
+    it("should pass", function() {
+      setFixtures(sandbox({'class': className}));
+      expect('#sandbox').toHaveClass(className);
+    });
+
+    it("should pass negated", function() {
+      setFixtures(sandbox());
+      expect('#sandbox').not.toHaveClass(className);
+    });
+
+    it("should not break built in matchers", function() {
+      setFixtures(sandbox());
+      expect('#sandbox').toEqual('#sandbox');
+    });
+
+    it("should not apply to built in matchers that are also in Jasmine jQuery", function() {
+      setFixtures(sandbox());
+      expect('+').toBe('+');
+      expect('just a string').toBe('just a string');
+    });
+
+  });
 });
 


### PR DESCRIPTION
Thanks for the feedback on my last pull request. I see that it broke the toBe() matcher. We want 

```
 expect('just a string').toBe('just a string'); 
```

to fall back to the built-in matcher rather than treating `'just a string'` like it's a jQuery selector. I think I solved the problem by just not having my shortcut apply to matchers that override built-in matchers. 
