### PR TITLE
toHaveText returns false when there's white space around the text

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -190,10 +190,11 @@ jasmine.JQuery.matchersClass = {};
     },
 
     toHaveText: function(text) {
+      var trimmedText = $.trim(this.actual.text());
       if (text && jQuery.isFunction(text.test)) {
-        return text.test(this.actual.text());
+        return text.test(trimmedText);
       } else {
-        return this.actual.text() == text;
+        return trimmedText == text;
       }
     },
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -474,6 +474,12 @@ describe("jQuery matchers", function() {
       expect(element.get(0)).toHaveText(text);
     });
 
+    it("should ignore surrounding whitespace", function() {
+      element = $('<div>\n' + text + '\n</div>');
+      expect(element).toHaveText(text);
+      expect(element.get(0)).toHaveText(text);
+    });
+
     it("should pass negated when text does not match", function() {
       expect(element).not.toHaveText(wrongText);
       expect(element.get(0)).not.toHaveText(wrongText);


### PR DESCRIPTION
When an element contains whitespace as part of the text (such as when
creating the HTML string with a templating library like _.template() in
Underscore.js), jQuery will return the preceding line breaks when
calling #text() on such an element. When we use toHaveText, we get false
even though the text does match.
