### PR TITLE
toHandle handles namespaced events

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -229,7 +229,21 @@ jasmine.JQuery.matchersClass = {};
     // tests the existence of a specific event binding
     toHandle: function(eventName) {
       var events = this.actual.data("events");
-      return events && events[eventName].length > 0;
+      if(typeof events === 'undefined') return false;
+
+      //namespaced event (e.g. click.myNameSpace)
+      if(/\./.test(eventName)){
+        var eventType = eventName.match(/^(\w+)\./)[1];
+        var eventNamespace = eventName.match(/^\w+\.(.*)/)[1];
+        var i;
+        if (typeof events[eventType] === 'undefined') return false;
+        for (i = 0; i < events[eventType].length; i++) {
+          if (events[eventType][i].namespace === eventNamespace) return true;
+        }
+        return false;
+      }
+
+      return events[eventName].length > 0;
     },
 
     // tests the existence of a specific event binding + handler

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -812,6 +812,18 @@ describe("jQuery matchers", function() {
       expect($('#clickme').get(0)).not.toHandle("click");
     });
 
+    it('should pass if the a namespaced event is bound', function(){
+      var handler = function(){ }; // noop
+      $('#clickme').bind("click", handler); //another event for the click array
+      $('#clickme').bind("click.NameSpace", handler);
+      expect($('#clickme')).toHandle("click.NameSpace");
+      expect($('#clickme').get(0)).toHandle("click.NameSpace");
+    });
+
+    it('should pass if a namespaced event is not bound', function() {
+      expect($('#clickme')).not.toHandle("click.NameSpace");
+      expect($('#clickme').get(0)).not.toHandle("click.NameSpace");
+    });
   });
   
   describe('toHandleWith', function() {


### PR DESCRIPTION
Works.  Here are the tests that pass now, to give you an idea of what it does:

``` javascript
it('should pass if the a namespaced event is bound', function(){
  var handler = function(){ }; // noop
  $('#clickme').bind("click", handler); //another event for the click array
  $('#clickme').bind("click.NameSpace", handler);
  expect($('#clickme')).toHandle("click.NameSpace");
  expect($('#clickme').get(0)).toHandle("click.NameSpace");
});

it('should pass if a namespaced event is not bound', function() {
  expect($('#clickme')).not.toHandle("click.NameSpace");
  expect($('#clickme').get(0)).not.toHandle("click.NameSpace");
});
```
