### PR TITLE
Do not trying to clone a non-DOM object

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -112,7 +112,11 @@ jasmine.JQuery.browserTagCaseIndependentHtml = function(html) {
 };
 
 jasmine.JQuery.elementToString = function(element) {
-  return jQuery('<div />').append($(element).clone()).html();
+  var sample = $(element).get()[0]
+  if (sample == undefined || sample.cloneNode)
+    return jQuery('<div />').append($(element).clone()).html();
+  else
+    return element.toString();
 };
 
 jasmine.JQuery.matchersClass = {};

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -812,6 +812,11 @@ describe("jQuery matchers", function() {
       expect($('#clickme').get(0)).not.toHandle("click");
     });
 
+    it('should handle event on any object', function(){
+      var object = new function(){ }; // noop
+      $(object).bind('click', function(){});
+      expect($(object)).toHandle('click');
+    })
   });
   
   describe('toHandleWith', function() {
@@ -840,6 +845,18 @@ describe("jQuery matchers", function() {
       expect($('#clickme').get(0)).not.toHandle("click");
     });
 
+    it("should pass if the event on window is bound with the given handler", function(){
+      var handler = function(){ };
+      $(window).bind("resize", handler)
+      expect($(window)).toHandleWith("resize", handler)
+    })
+
+    it("should pass if the event on any object is bound with the given handler", function(){
+      var object = new function(){ }; // noop
+      var handler = function(){ };
+      $(object).bind('click', handler);
+      expect($(object)).toHandleWith('click', handler);
+    })
   });
 });
 


### PR DESCRIPTION
Previously, elementToString() function would trying to clone any object
passed to it for displaying in the test result. However, this would fail
if the user is trying to test anything against a non-DOM object, such as
a function. This commit make sure that the element is clonable before
attempting to clone it.
