### PR TITLE
Fix for #70 (jquery matchers on document.documentElement break jasmine engine)

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -265,7 +265,8 @@ jasmine.JQuery.matchersClass = {};
              || jasmine.isDomNode(this.actual))) {
           this.actual = $(this.actual);
           var result = jQueryMatchers[methodName].apply(this, arguments)
-          if (this.actual.get && !$.isWindow(this.actual.get()[0])) 
+          var element;      	
+          if (this.actual.get && (element = this.actual.get()[0]) && !$.isWindow(element) && element.tagName !== "HTML") 
             this.actual = jasmine.JQuery.elementToString(this.actual)
         return result;
       }


### PR DESCRIPTION
This is a straightforward fix for the issue #70.
Thanks
