### PR TITLE
Issue #48 and #56 Fix + Cleanup

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -46,7 +46,7 @@ jasmine.Fixtures.prototype.set = function(html) {
 };
 
 jasmine.Fixtures.prototype.appendSet= function(html) {
-  this.addToContainer_(html)
+  this.addToContainer_(html);
 }
 
 jasmine.Fixtures.prototype.preload = function() {
@@ -60,7 +60,7 @@ jasmine.Fixtures.prototype.load = function() {
 
 jasmine.Fixtures.prototype.appendLoad = function() {
   this.addToContainer_(this.read.apply(this, arguments));
-}
+};
 
 jasmine.Fixtures.prototype.read = function() {
   var htmlChunks = [];
@@ -92,7 +92,7 @@ jasmine.Fixtures.prototype.createContainer_ = function(html) {
     container = jQuery('<div id="' + this.containerId + '" />');
     container.html(html);
   } else {
-    container = '<div id="' + this.containerId + '">' + html + '</div>'
+    container = '<div id="' + this.containerId + '">' + html + '</div>';
   }
   jQuery('body').append(container);
 };
@@ -102,7 +102,7 @@ jasmine.Fixtures.prototype.addToContainer_ = function(html){
   if(!container.length){
     this.createContainer_(html);
   }
-}
+};
 
 jasmine.Fixtures.prototype.getFixtureHtml_ = function(url) {
   if (typeof this.fixturesCache_[url] === 'undefined') {
@@ -135,8 +135,8 @@ jasmine.JQuery.browserTagCaseIndependentHtml = function(html) {
 };
 
 jasmine.JQuery.elementToString = function(element) {
-  var domEl = $(element).get(0)
-  if (domEl == undefined || domEl.cloneNode)
+  var domEl = $(element).get(0);
+  if (domEl === undefined || domEl.cloneNode)
     return jQuery('<div />').append($(element).clone()).html();
   else
     return element.toString();
@@ -171,7 +171,7 @@ jasmine.JQuery.matchersClass = {};
       data.spiedEvents = {};
       data.handlers    = [];
     }
-  }
+  };
 })(jasmine.JQuery);
 
 (function(){
@@ -182,9 +182,9 @@ jasmine.JQuery.matchersClass = {};
 
     toHaveCss: function(css){
       for (var prop in css){
-        if (this.actual.css(prop) !== css[prop]) return false
+        if (this.actual.css(prop) !== css[prop]) return false;
       }
-      return true
+      return true;
     },
 
     toBeVisible: function() {
@@ -228,9 +228,9 @@ jasmine.JQuery.matchersClass = {};
     },
 
     toContainHtml: function(html){
-      var actualHtml = this.actual.html()
-      var expectedHtml = jasmine.JQuery.browserTagCaseIndependentHtml(html)
-      return (actualHtml.indexOf(expectedHtml) >= 0)
+      var actualHtml = this.actual.html();
+      var expectedHtml = jasmine.JQuery.browserTagCaseIndependentHtml(html);
+      return (actualHtml.indexOf(expectedHtml) >= 0);
     },
 
     toHaveText: function(text) {
@@ -267,33 +267,29 @@ jasmine.JQuery.matchersClass = {};
     },
 
     // tests the existence of a specific event binding
-    toHandle: function(eventName) {
-      var events = this.actual.data("events");
-      
-      if(typeof events === 'undefined') return false;
+    toHandle: function(event) {
 
-      //namespaced event (e.g. click.myNameSpace)
-      //only test one namespace at a time (click.one & click.two rather than click.one.two)
-      if(/\./.test(eventName)){
-        var eventType = eventName.match(/^(\w+)\./)[1];
-        var eventNamespace = eventName.match(/\.(.*)/)[1];
-        var i;
-        if (typeof events[eventType] === 'undefined'){ return false };
-        var numOfEvents = events[eventType].length;
-        //loop thru the events
-        for (i = 0; i < numOfEvents; i++) {
-          var namespaces = events[eventType][i].namespace.split(".");
-          var j;
-          //loop thru the namespaces on that event
-          for(j = 0; j < namespaces.length; j++){
-            if(eventNamespace === namespaces[j]){ return true;}
-          }
-        }
+      var events = this.actual.data('events');
+
+      if(!events || !event || typeof event !== "string") {
         return false;
       }
 
-      return events[eventName].length > 0;
+      var namespaces = event.split(".");
+      var eventType = namespaces.shift();
+      var namespace_sort = namespaces.slice(0).sort();
+      var namespace_re = new RegExp("(^|\\.)" + namespace_sort.join("\\.(?:.*\\.)?") + "(\\.|$)");
 
+      if(events[eventType] && namespaces.length) {
+        for(var i = 0; i < events[eventType].length; i++) {
+          var _namespace = events[eventType][i].namespace;
+          if(namespace_re.test(_namespace)) {
+            return true;
+          }
+        }
+      }else {
+        return events[eventType] && events[eventType].length > 0;
+      }
     },
 
     // tests the existence of a specific event binding + handler
@@ -320,14 +316,12 @@ jasmine.JQuery.matchersClass = {};
     var builtInMatcher = jasmine.Matchers.prototype[methodName];
 
     jasmine.JQuery.matchersClass[methodName] = function() {
-      if (this.actual
-          && (this.actual instanceof jQuery
-             || jasmine.isDomNode(this.actual))) {
+      if (this.actual && (this.actual instanceof jQuery || jasmine.isDomNode(this.actual))) {
           this.actual = $(this.actual);
-          var result = jQueryMatchers[methodName].apply(this, arguments)
-          var element;      	
+          var result = jQueryMatchers[methodName].apply(this, arguments);
+          var element;
           if (this.actual.get && (element = this.actual.get()[0]) && !$.isWindow(element) && element.tagName !== "HTML") 
-            this.actual = jasmine.JQuery.elementToString(this.actual)
+            this.actual = jasmine.JQuery.elementToString(this.actual);
         return result;
       }
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -961,9 +961,9 @@ describe("jQuery matchers", function() {
       expect($('#clickme')).toHandle("click.NameSpace");
     });
 
-    it('should work with all valid namespaces', function(){
-      $('#clickme').bind("click.Name-1!@#$%^&*?,[]{}_()Space", handler);
-      expect($('#clickme')).toHandle("click.Name-1!@#$%^&*?,[]{}_()Space");
+    it('should not fail when events is empty', function() {
+      $('#clickme').change(function() { });
+      expect($('#clickme')).not.toHandle('click');
     });
   
     it('should recognize an event with multiple namespaces', function(){
@@ -971,6 +971,9 @@ describe("jQuery matchers", function() {
       expect($('#clickme')).toHandle("click.NSone");
       expect($('#clickme')).toHandle("click.NStwo");
       expect($('#clickme')).toHandle("click.NSthree");
+      expect($('#clickme')).toHandle("click.NSthree.NStwo");
+      expect($('#clickme')).toHandle("click.NStwo.NSone");
+      expect($('#clickme')).toHandle("click");
     });
 
     it('should pass if a namespaced event is not bound', function() {


### PR DESCRIPTION
- fix for https://github.com/velesin/jasmine-jquery/issues/48
- fix for https://github.com/velesin/jasmine-jquery/issues/56.  
- added jshint suggestions
-  removed an invalid test case below since some of those characters appear to be invalid for namespaces (see discussion see http://bugs.jquery.com/ticket/11458 and jsfiddle example http://jsfiddle.net/robmcguinness/geafB/17/)

``` javascript
it('should work with all valid namespaces', function(){
  $('#clickme').bind("click.Name-1!@#$%^&*?,[]{}_()Space", handler);
  expect($('#clickme')).toHandle("click.Name-1!@#$%^&*?,[]{}_()Space");
});
```
