### PR TITLE
Fix Issue #48 and #56

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -267,33 +267,29 @@ jasmine.JQuery.matchersClass = {};
     },
 
     // tests the existence of a specific event binding
-    toHandle: function(eventName) {
-      var events = this.actual.data("events");
-      
-      if(typeof events === 'undefined') return false;
+    toHandle: function(event) {
 
-      //namespaced event (e.g. click.myNameSpace)
-      //only test one namespace at a time (click.one & click.two rather than click.one.two)
-      if(/\./.test(eventName)){
-        var eventType = eventName.match(/^(\w+)\./)[1];
-        var eventNamespace = eventName.match(/\.(.*)/)[1];
-        var i;
-        if (typeof events[eventType] === 'undefined'){ return false };
-        var numOfEvents = events[eventType].length;
-        //loop thru the events
-        for (i = 0; i < numOfEvents; i++) {
-          var namespaces = events[eventType][i].namespace.split(".");
-          var j;
-          //loop thru the namespaces on that event
-          for(j = 0; j < namespaces.length; j++){
-            if(eventNamespace === namespaces[j]){ return true;}
-          }
-        }
+      var events = this.actual.data('events');
+
+      if(!events || !event || typeof event !== "string") {
         return false;
       }
 
-      return events[eventName].length > 0;
+      var namespaces = event.split(".");
+      var eventType = namespaces.shift();
+      var namespace_sort = namespaces.slice(0).sort();
+      var namespace_re = new RegExp("(^|\\.)" + namespace_sort.join("\\.(?:.*\\.)?") + "(\\.|$)");
 
+      if(events[eventType] && namespaces.length) {
+        for(var i = 0; i < events[eventType].length; i++) {
+          var _namespace = events[eventType][i].namespace;
+          if(namespace_re.test(_namespace)) {
+            return true;
+          }
+        }
+      }else {
+        return events[eventType] && events[eventType].length > 0;
+      }
     },
 
     // tests the existence of a specific event binding + handler

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -961,9 +961,9 @@ describe("jQuery matchers", function() {
       expect($('#clickme')).toHandle("click.NameSpace");
     });
 
-    it('should work with all valid namespaces', function(){
-      $('#clickme').bind("click.Name-1!@#$%^&*?,[]{}_()Space", handler);
-      expect($('#clickme')).toHandle("click.Name-1!@#$%^&*?,[]{}_()Space");
+    it('should not fail when events is empty', function() {
+      $('#clickme').change(function() { });
+      expect($('#clickme')).not.toHandle('click');
     });
   
     it('should recognize an event with multiple namespaces', function(){
@@ -971,6 +971,9 @@ describe("jQuery matchers", function() {
       expect($('#clickme')).toHandle("click.NSone");
       expect($('#clickme')).toHandle("click.NStwo");
       expect($('#clickme')).toHandle("click.NSthree");
+      expect($('#clickme')).toHandle("click.NSthree.NStwo");
+      expect($('#clickme')).toHandle("click.NStwo.NSone");
+      expect($('#clickme')).toHandle("click");
     });
 
     it('should pass if a namespaced event is not bound', function() {


### PR DESCRIPTION
- fix for https://github.com/velesin/jasmine-jquery/issues/48
- fix for https://github.com/velesin/jasmine-jquery/issues/56.  
-  removed an invalid test case below since some of those characters appear to be invalid for namespaces (see discussion see http://bugs.jquery.com/ticket/11458 and jsfiddle example http://jsfiddle.net/robmcguinness/geafB/17/)

``` javascript
it('should work with all valid namespaces', function(){
  $('#clickme').bind("click.Name-1!@#$%^&*?,[]{}_()Space", handler);
  expect($('#clickme')).toHandle("click.Name-1!@#$%^&*?,[]{}_()Space");
});
```

Signed-off-by: robert mcguinness robert.mcguinness.iii@gmail.com
