### PR TITLE
Allow support for spying on document for events.

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -27,7 +27,11 @@ var sandbox = function(attributes) {
 }
 
 var spyOnEvent = function(selector, eventName) {
-  return jasmine.JQuery.events.spyOn($(selector).selector, eventName)
+  return jasmine.JQuery.events.spyOn(selector, eventName)
+}
+
+jasmine.spiedEventsKey = function (selector, eventName) {
+  return [$(selector).selector, eventName].toString();
 }
 
 jasmine.getFixtures = function() {
@@ -153,7 +157,7 @@ jasmine.JQuery.matchersClass = {};
   namespace.events = {
     spyOn: function(selector, eventName) {
       var handler = function(e) {
-        data.spiedEvents[[selector, eventName]] = e
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = e
       }
       jQuery(selector).bind(eventName, handler)
       data.handlers.push(handler)
@@ -162,17 +166,17 @@ jasmine.JQuery.matchersClass = {};
         eventName: eventName,
         handler: handler,
         reset: function(){
-          delete data.spiedEvents[[this.selector, this.eventName]];
+          delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)];
         }
       }
     },
 
     wasTriggered: function(selector, eventName) {
-      return !!(data.spiedEvents[[selector, eventName]])
+      return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
     },
 
     wasPrevented: function(selector, eventName) {
-      return data.spiedEvents[[selector, eventName]].isDefaultPrevented()
+      return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].isDefaultPrevented()
     },
 
     cleanUp: function() {
@@ -352,7 +356,7 @@ beforeEach(function() {
           "Expected event " + this.actual + " not to have been triggered on " + selector
         ]
       }
-      return jasmine.JQuery.events.wasTriggered($(selector).selector, this.actual)
+      return jasmine.JQuery.events.wasTriggered(selector, this.actual)
     }
   })
   this.addMatchers({
@@ -376,7 +380,7 @@ beforeEach(function() {
           "Expected event " + this.actual + " not to have been prevented on " + selector
         ]
       }
-      return jasmine.JQuery.events.wasPrevented($(selector).selector, this.actual)
+      return jasmine.JQuery.events.wasPrevented(selector, this.actual)
     }
   })
   this.addMatchers({

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -884,6 +884,7 @@ describe("jQuery matchers", function() {
     beforeEach(function() {
       setFixtures(sandbox().html('<a id="clickme">Click Me</a> <a id="otherlink">Other Link</a>'))
       spyOnEvent($('#clickme'), 'click')
+      spyOnEvent(document, 'click')
       spyOnEvent($('#otherlink'), 'click')
     })
 
@@ -891,6 +892,18 @@ describe("jQuery matchers", function() {
       $('#clickme').click()
       expect('click').toHaveBeenTriggeredOn($('#clickme'))
       expect('click').toHaveBeenTriggeredOn('#clickme')
+    })
+
+    it('should pass if the event was triggered on document', function() {
+      $(document).click()
+      expect('click').toHaveBeenTriggeredOn($(document))
+      expect('click').toHaveBeenTriggeredOn(document)
+    })
+
+    it('should pass if the event was triggered on a descendant of document', function() {
+      $('#clickme').click()
+      expect('click').toHaveBeenTriggeredOn($(document))
+      expect('click').toHaveBeenTriggeredOn(document)
     })
 
     it('should pass negated if the event was never triggered', function() {


### PR DESCRIPTION
Currently,

```
spyOnEvent(document, 'eventName');
```

doesn't work, because the code:

```
$(selector).selector;
```

returns `''` when `selector` is `document`. This branch changes the above to:

```
$(selector).selector || selector;
```

which will return the original `document` object if the jQuery code returns an empty string. I moved this code into a helper function and added a few specs to test this new behaviour.
