### PR TITLE
Use jQuery for ajax requests.

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -113,9 +113,11 @@ jasmine.Fixtures.prototype.getFixtureHtml_ = function(url) {
 
 jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function(relativeUrl) {
   var url = this.makeFixtureUrl_(relativeUrl)
-  var request = new XMLHttpRequest()
-  request.open("GET", url + "?" + new Date().getTime(), false)
-  request.send(null)
+  var request = jQuery.ajax({
+    type: "GET",
+    url: url + "?" + new Date().getTime(),
+    async: false
+  })
   this.fixturesCache_[relativeUrl] = request.responseText
 }
 


### PR DESCRIPTION
I needed to run my tests in IE6 so I've replaced the use of `XMLHttpRequest` with `jQuery.ajax`.

A couple of tests still fail in IE6 and IE7 (they failed before anyway)--I'm assuming you don't officially support those browsers.
