### PR TITLE
fix loadStyleFixtures function in IE8

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -201,7 +201,9 @@ jasmine.StyleFixtures.prototype.cleanUp = function() {
 }
 
 jasmine.StyleFixtures.prototype.createStyle_ = function(html) {
-  var style = jQuery('<style></style>').text(html)
+  var styleText = $('<div></div>').html(html).text()
+
+  var style = jQuery('<style>' + styleText + '</style>')
 
   this.fixturesNodes_.push(style)
 


### PR DESCRIPTION
when testing on IE8, the css style fixtures can not be loaded by

```
var style = jQuery('<style></style>').text(html)

jQuery('head').append(style)
```

because the property of STYLE tag in IE8 is read-only, see this  in [stackoverflow](http://stackoverflow.com/questions/2692770/style-style-textcss-appendtohead-does-not-work-in-ie#bqwtz), but it works in IE9.

> The property is read/write for all objects except the following, for which it is read-only: COL, COLGROUP, FRAMESET, HEAD, HTML, STYLE, TABLE, TBODY, TFOOT, THEAD, TITLE, TR.
