### PR TITLE
Allows inclusion in specs even when jQuery (specifically $) may not be defined.

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -114,8 +114,9 @@ jasmine.Fixtures.prototype.clearCache = function() {
 }
 
 jasmine.Fixtures.prototype.cleanUp = function() {
-  if (typeof($) == 'undefined') return;
-  $('#' + this.containerId).remove()
+  if (typeof($) == 'function') {
+    $('#' + this.containerId).remove()
+  }
 }
 
 jasmine.Fixtures.prototype.sandbox = function(attributes) {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -325,11 +325,13 @@ describe("jasmine.Fixtures", function() {
   })
 
   describe("cleanUp", function() {
-    it("shouldn't bark if $ (zepto, jQuery, etc) isn't defined", function() {
-      var $ = window.$;
-      window.$ = undefined;
+    afterEach(function() {
+      window.$ = window.jQuery;
+    })
+
+    it("should work even if $ (zepto, jQuery, etc) isn't defined", function() {
+      window.$ = undefined
       jasmine.getFixtures().cleanUp()
-      window.$ = $;
     })
     
     it("should remove fixtures container from DOM", function() {


### PR DESCRIPTION
This allows me to always include jasmine-jquery even if jquery isn't being used for a given spec.
