### PR TITLE
wasPrevented null check, for untriggered events.

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -317,7 +317,8 @@ jasmine.JQuery.matchersClass = {}
     },
 
     wasPrevented: function(selector, eventName) {
-      return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].isDefaultPrevented()
+      var e;
+      return (e = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]) && e.isDefaultPrevented()
     },
 
     cleanUp: function() {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1012,6 +1012,10 @@ describe("jQuery matchers", function() {
       expect(spyEvents['#clickme']).not.toHaveBeenPrevented()
     })
 
+    it('should pass negated if nothing was triggered', function() {
+      expect(spyEvents['#clickme']).not.toHaveBeenPrevented()
+    })
+
   })
 
   describe('toHandle', function() {


### PR DESCRIPTION
Fixing an 'undefined' error I was getting when calling .toBePrevented() on an event that wasn't triggered.
