### PR TITLE
Updating deprecated $.ajax params

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -260,10 +260,10 @@ jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function(relativeUrl) {
     cache: false,
     dataType: 'json',
     url: url,
-    success: function(data) {
+    done: function(data) {
       self.fixturesCache_[relativeUrl] = data
     },
-    error: function(jqXHR, status, errorThrown) {
+    fail: function(jqXHR, status, errorThrown) {
         throw Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + errorThrown.message + ')')
     }
   })


### PR DESCRIPTION
success/error/complete are deprecated in favor of done/fail/always http://bugs.jquery.com/ticket/9399
