### PR TITLE
Update toBeFocused to be compatible with PhantomJS

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -421,7 +421,7 @@ jasmine.JQuery.matchersClass = {}
     },
 
     toBeFocused: function(selector) {
-      return this.actual.is(':focus')
+      return this.actual[0] === this.actual[0].ownerDocument.activeElement
     },
 
     toHandle: function(event) {


### PR DESCRIPTION
Due to this [PhantomJS bug](http://code.google.com/p/phantomjs/issues/detail?id=427), the current implementation of `toBeFocused` will always fail. Rather than rely on `jQuery#is(':focus')`, this pull request does a comparison with the `activeElement`. See #37 for a brief discussion on the matter.
