### PR TITLE
Make event spy arguments available

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -297,8 +297,10 @@ jasmine.JQuery.matchersClass = {}
 
   namespace.events = {
     spyOn: function(selector, eventName) {
-      var handler = function(e) {
-        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = e
+      var eventArgs = [];
+      var handler = function() {
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = arguments[0]
+        eventArgs.push(arguments);
       }
       $(selector).bind(eventName, handler)
       data.handlers.push(handler)
@@ -306,8 +308,10 @@ jasmine.JQuery.matchersClass = {}
         selector: selector,
         eventName: eventName,
         handler: handler,
+        argsForEvent: eventArgs,
         reset: function(){
           delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+          eventArgs.length = 0;
         }
       }
     },

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1048,6 +1048,17 @@ describe("jQuery matchers", function() {
 
   })
 
+  it('should make event arguments available', function() {
+    var spyEvent = spyOnEvent('body', 'test');
+    $('body').trigger('test', ['arg1', 'arg2']);
+    $('body').trigger('test', 'arg3');
+    expect(spyEvent.argsForEvent[0][1]).toEqual('arg1');
+    expect(spyEvent.argsForEvent[0][2]).toEqual('arg2');
+    expect(spyEvent.argsForEvent[1][1]).toEqual('arg3');
+    spyEvent.reset();
+    expect(spyEvent.argsForEvent).toEqual([]);
+  });
+
   describe('toHandle', function() {
     var handler
     beforeEach(function() {


### PR DESCRIPTION
It is useful to be able to check that an event was triggered with specific arguments.  This change allows you to do so the same way "argsForCall" allows you to do this with spy function invocations.
