### PR TITLE
adding a clearer expectation failed message for toHaveData matcher

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -1,8 +1,8 @@
 /*!
  Jasmine-jQuery: a set of jQuery helpers for Jasmine tests.
- 
+
  Version 1.5.0
- 
+
  https://github.com/velesin/jasmine-jquery
 
  Copyright (c) 2010-2013 Wojciech Zawistowski, Travis Jeffery
@@ -433,7 +433,23 @@ jasmine.JQuery.matchersClass = {}
     },
 
     toHaveData: function(key, expectedValue) {
-      return hasProperty(this.actual.data(key), expectedValue)
+      var node = this.actual;
+      var actualValue = node.data(key);
+      this.message = function() {
+        if (!expectedValue || !actualValue) {
+          return [
+            "Expected '" + node.get(0).outerHTML + "' to have data '" + key +"'.",
+            "Expected '" + node.get(0).outerHTML + "' not to have data '" + key +"'."
+          ]
+        }
+        else {
+          return [
+            "Expected node to have '" + expectedValue + "' in data-" + key + " attribute, found " + actualValue + "instead.",
+            "Expected node not to have '" + expectedValue + "' in data-" + key + " attribute",
+          ]
+        }
+      }
+      return hasProperty(actualValue, expectedValue)
     },
 
     toBe: function(selector) {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -677,6 +677,8 @@ describe("jQuery matchers", function() {
       setFixtures(sandbox().data(key, value))
     })
 
+    var failing_spec = it("a mock spec just to test expectation failure messages", function() { });
+
     describe("when only key is provided", function() {
       it("should pass if element has matching data key", function() {
         expect($('#sandbox')).toHaveData(key)
@@ -686,6 +688,14 @@ describe("jQuery matchers", function() {
       it("should pass negated if element has no matching data key", function() {
         expect($('#sandbox')).not.toHaveData(wrongKey)
         expect($('#sandbox').get(0)).not.toHaveData(wrongKey)
+      })
+
+      it("should give a message that helps understanding how the expectation was not met", function() {
+        var node = $("#sandbox");
+        var matcher = failing_spec.expect(node);
+        matcher.toHaveData(wrongKey);
+        var result = failing_spec.results().getItems()[0];
+        expect(result.message).toEqual("Expected '"+node.get(0).outerHTML+"' to have data 'wrong key'.");
       })
     })
 
@@ -703,6 +713,15 @@ describe("jQuery matchers", function() {
       it("should pass negated if element has no matching key", function() {
         expect($('#sandbox')).not.toHaveData(wrongKey, value)
         expect($('#sandbox').get(0)).not.toHaveData(wrongKey, value)
+      })
+
+      it("should give a message that helps understanding how the expectation was not met", function() {
+        var node = $("#sandbox");
+        var matcher = failing_spec.expect(node.get(0));
+        matcher.toHaveData(key, wrongValue);
+        var result = failing_spec.results().getItems()[0];
+
+        expect(result.message).toEqual("Expected '"+node.get(0).outerHTML+"' to have data 'wrong key'.");
       })
     })
   })


### PR DESCRIPTION
Currently, when a toHaveData matcher fails, it's a bit non-specific as to why it has failed, simply saying it expected the element to have a data-attribute named as expected.

This patch makes the expectation failed message more specific, differentiating between the following cases:
- data attribute was not present at all or no expected value was passed
- data attribtue was present, but its value does not match the expected value

Also: I am not entirely satisfied with the way I wrote those tests, and appreciate feedbak on that :)
