### PR TITLE
Fix Ajax option fail to error@JSONFixture.

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -291,7 +291,7 @@ jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function(relativeUrl) {
     success: function(data) {
       self.fixturesCache_[relativeUrl] = data
     },
-    fail: function(jqXHR, status, errorThrown) {
+    error: function(jqXHR, status, errorThrown) {
         throw Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + errorThrown.message + ')')
     }
   })


### PR DESCRIPTION
When I tried to use getJSONFixture methods, it didn't work.
I'm using jasmine-jquery with jasmine-gem in RoR.

I think fail option for $.ajax doesn't seem to exist.

My env is like below.
jquery -> v1.9.1
jasmine jquery -> Version 1.5.0

But it's refixing of recent commit.
Here's commit No.
<fafeb7189e7c4bbded7b27d9ca83f0fac04fb32b>

see it.
