### PR TITLE
Add toHaveBeenTriggeredOnAndWith jasmine helper

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,8 @@ jasmine-jquery provides following custom matchers (in alphabetical order):
   - if event has been triggered on `selector` (see "Event Spies", below)
 - `toHaveBeenTriggered()`
   - if event has been triggered on `selector` (see "Event Spies", below)
+- `toHaveBeenTriggeredOnAndWith(selector, extraParameters)`
+  - if event has been triggered on `selector` and with `extraParameters`
 - `toHaveBeenPreventedOn(selector)`
   - if event has been prevented on `selector` (see "Event Spies", below)
 - `toHaveBeenPrevented()`

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -326,7 +326,7 @@ jasmine.JQuery.matchersClass = {}
   namespace.events = {
     spyOn: function(selector, eventName) {
       var handler = function(e) {
-        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = e
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = jasmine.util.argsToArray(arguments)
       }
       $(selector).bind(eventName, handler)
       data.handlers.push(handler)
@@ -340,13 +340,32 @@ jasmine.JQuery.matchersClass = {}
       }
     },
 
+    args: function(selector, eventName) {
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)];
+
+      if (!actualArgs) {
+        throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent.";
+      }
+
+      return actualArgs;
+    },
+
     wasTriggered: function(selector, eventName) {
       return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
     },
 
+    wasTriggeredWith: function(selector, eventName, expectedArgs, env) {
+      var actualArgs = jasmine.JQuery.events.args(selector, eventName).slice(1);
+      if (Object.prototype.toString.call(expectedArgs) !== '[object Array]') {
+        actualArgs = actualArgs[0];
+      }
+      return env.equals_(expectedArgs, actualArgs);
+    },
+
     wasPrevented: function(selector, eventName) {
-      var e;
-      return (e = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]) && e.isDefaultPrevented()
+      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)],
+          e = args ? args[0] : undefined;
+      return e && e.isDefaultPrevented()
     },
 
     cleanUp: function() {
@@ -545,6 +564,28 @@ beforeEach(function() {
       }
       return jasmine.JQuery.events.wasTriggered(selector, eventName)
      }
+  })
+  this.addMatchers({
+    toHaveBeenTriggeredOnAndWith: function() {
+      var selector = arguments[0],
+          expectedArgs = arguments[1],
+          wasTriggered = jasmine.JQuery.events.wasTriggered(selector, this.actual);
+      this.message = function() {
+        if (wasTriggered) {
+          var actualArgs = jasmine.JQuery.events.args(selector, this.actual, expectedArgs)[1];
+          return [
+            "Expected event " + this.actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs),
+            "Expected event " + this.actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs)
+          ]
+        } else {
+          return [
+            "Expected event " + this.actual + " to have been triggered on " + selector,
+            "Expected event " + this.actual + " not to have been triggered on " + selector
+          ]
+        }
+      }
+      return wasTriggered && jasmine.JQuery.events.wasTriggeredWith(selector, this.actual, expectedArgs, this.env);
+    }
   })
   this.addMatchers({
     toHaveBeenPreventedOn: function(selector) {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -948,6 +948,64 @@ describe("jQuery matchers", function() {
     })
   })
 
+  describe('toHaveBeenTriggeredOnAndWith', function() {
+    beforeEach(function() {
+      spyOnEvent(document, 'event')
+    })
+
+    describe("when extra parameter is an object", function() {
+      it('should pass if the event was triggered on the object with expected arguments', function() {
+        $(document).trigger('event', { key1: "value1", key2: "value2" })
+        expect('event').toHaveBeenTriggeredOnAndWith(document, { key1: "value1", key2: "value2" })
+      })
+
+      it('should pass negated if the event was never triggered', function() {
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, { key1: "value1", key2: "value2" })
+      })
+
+      it('should pass negated if the event was triggered on another non-descendant object', function() {
+        $(window).trigger('event', { key1: "value1", key2: "value2" })
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, { key1: "value1", key2: "value2" })
+      })
+
+      it('should pass negated if the event was triggered but the arguments do not match with the expected arguments', function() {
+        $(document).trigger('event', { key1: "value1" })
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, { key1: "value1", key2: "value2" })
+        $(document).trigger('event', { key1: "value1", key2: "value2" })
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, { key1: "value1" })
+        $(document).trigger('event', { key1: "different value" })
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, { key1: "value1" })
+        $(document).trigger('event', { different_key: "value1" })
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, { key1: "value1" })
+      })
+    })
+
+    describe("when extra parameter is an array", function() {
+      it('should pass if the event was triggered on the object with expected arguments', function() {
+        $(document).trigger('event', [1, 2])
+        expect('event').toHaveBeenTriggeredOnAndWith(document, [1, 2])
+      })
+
+      it('should pass negated if the event was never triggered', function() {
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, [1, 2])
+      })
+
+      it('should pass negated if the event was triggered on another non-descendant object', function() {
+        $(window).trigger('event', [1, 2])
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, [1, 2])
+      })
+
+      it('should pass negated if the event was triggered but the arguments do not match with the expected arguments', function() {
+        $(document).trigger('event', [1])
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, [1, 2])
+        $(document).trigger('event', [1, 2])
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, [1])
+        $(document).trigger('event', [1, 3])
+        expect('event').not.toHaveBeenTriggeredOnAndWith(document, [1, 2])
+      })
+    })
+  })
+
   describe('toHaveBeenTriggered', function() {
     var spyEvents = {}
     beforeEach(function() {


### PR DESCRIPTION
jQuery's `trigger` method allows us to pass extra parameter as an object or array in addition to an event name.

This PR adds `toHaveBeenTriggeredOnAndWith` function that checks if a given event is triggered on expected jQuery object with expected extra parameter.
