### PR TITLE
Add toContainText expectation

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -1,8 +1,8 @@
 /*!
  Jasmine-jQuery: a set of jQuery helpers for Jasmine tests.
- 
+
  Version 1.5.0
- 
+
  https://github.com/velesin/jasmine-jquery
 
  Copyright (c) 2010-2013 Wojciech Zawistowski, Travis Jeffery
@@ -425,6 +425,15 @@ jasmine.JQuery.matchersClass = {}
         return text.test(trimmedText)
       } else {
         return trimmedText == text
+      }
+    },
+
+    toContainText: function(text) {
+      var trimmedText = $.trim(this.actual.text())
+      if (text && $.isFunction(text.test)) {
+        return text.test(trimmedText)
+      } else {
+        return trimmedText.indexOf(text) != -1;
       }
     },
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -638,6 +638,37 @@ describe("jQuery matchers", function() {
     })
   })
 
+  describe("toContainText", function() {
+    var text = 'some pretty long bits of text'
+    var textPart = 'pret';
+    var wrongText = 'some other text'
+    var element
+
+    beforeEach(function() {
+      element = $('<div/>').append(text)
+    })
+
+    it("should pass when text contains text part", function() {
+      expect(element).toContainText(textPart)
+      expect(element.get(0)).toContainText(textPart)
+    })
+
+    it("should pass negated when text does not match", function() {
+      expect(element).not.toContainText(wrongText)
+      expect(element.get(0)).not.toContainText(wrongText)
+    })
+
+    it('should pass when text matches a regex', function() {
+      expect(element).toContainText(/some/)
+      expect(element.get(0)).toContainText(/some/)
+    })
+
+    it('should pass negated when text does not match a regex', function() {
+      expect(element).not.toContainText(/other/)
+      expect(element.get(0)).not.toContainText(/other/)
+    })
+  })
+
   describe("toHaveValue", function() {
     var value = 'some value'
     var differentValue = 'different value'


### PR DESCRIPTION
Similar to how there is both `toHaveHtml` and `toContainHtml`.

Returns true if the passed text exists in the element's text even if the element's text is longer.
Returns false if the passed text doesn't exist in the element's text.
