### PR TITLE
Move from .bind() to .on()

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -328,7 +328,7 @@ jasmine.JQuery.matchersClass = {}
       var handler = function(e) {
         data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = e
       }
-      $(selector).bind(eventName, handler)
+      $(selector).on(eventName, handler)
       data.handlers.push(handler)
       return {
         selector: selector,


### PR DESCRIPTION
In jQuery 2.0 `bind()` has been moved into a separate event-alias module and when using a custom jQuery build without it, jasmine-jquery breaks.

`bind()` has been deprecated [and calls `.on()` anyway](https://github.com/jquery/jquery/blob/master/src/event-alias.js#L18).

Details here - http://bugs.jquery.com/ticket/13554
