### PR TITLE
Calls isPropagationStopped on the jQueryEvent at [0] instead of on the a...

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -369,8 +369,9 @@ jasmine.JQuery.matchersClass = {}
     },
 
     wasStopped: function(selector, eventName) {
-      var e;
-      return (e = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]) && e.isPropagationStopped()
+      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)],
+          e = args ? args[0] : undefined;
+      return e && e.isPropagationStopped()
     },
 
     cleanUp: function() {


### PR DESCRIPTION
When running the test i found that six tests using the wasStopped() method was failing because it tried to call isPropagationStopped on an array instead of the jqueryEvent. 

Changed it to work like wasPrevented()

You could perhaps dry it up a bit more by putting the repeated code into a function of some sort.
