### PR TITLE
Added toContainNumberOfElements-matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ jasmine-jquery provides following custom matchers (in alphabetical order):
   - Elements are considered visible if they consume space in the document. Visible elements have a width or height that is greater than zero.
 - `toContain(jQuerySelector)`
   - e.g. `expect($('<div><span class="some-class"></span></div>')).toContain('span.some-class')`
+- `toContainNumberOfElements(number, jQuerySelector)`
+  - if an element contain exact number of another
+  - e.g. `expect($('<div><span class="some-class"></span><span class="some-other-class"></span></div>')).toContainNumberOfElements(2, 'span')`
 - `toExist()`
 - `toHaveAttr(attributeName, attributeValue)`
   - attribute value is optional, if omitted it will check only if attribute exists

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -478,6 +478,10 @@ jasmine.JQuery.matchersClass = {}
       return this.actual.find(selector).length
     },
 
+    toContainNumberOfElements: function(number, selector) {
+      return this.actual.find(selector).length === number
+    },
+
     toBeDisabled: function(selector){
       return this.actual.is(':disabled')
     },

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -907,6 +907,24 @@ describe("jQuery matchers", function() {
     })
   })
 
+  describe("toContainNumberOfElements", function() {
+    beforeEach(function() {
+      setFixtures(sandbox().html('<div class=outer><div class="inner"><select><option>option 1</option><option>option 2</option><option>option 3</option></select></div></div>'))
+    })
+
+    it("should pass if object contains correct number of selector", function() {
+      expect($('#sandbox')).toContainNumberOfElements(2, 'div')
+      expect($('#sandbox').find('select')).toContainNumberOfElements(3, 'option')
+      expect($('#sandbox')).toContainNumberOfElements(0, 'span')
+    })
+
+    it("should pass negated if object does not contain correct number of  selector", function() {
+      expect($('#sandbox')).not.toContainNumberOfElements(3, 'div')
+      expect($('#sandbox').find('select')).not.toContainNumberOfElements(4, 'option')
+      expect($('#sandbox')).not.toContainNumberOfElements(1, 'span')
+    })
+  })
+
   describe("toBeDisabled", function() {
     beforeEach(function() {
       setFixtures('\


### PR DESCRIPTION
I found myself writing many specs checking that an element contained the correct number of buttons, or options in a dropdown-list.

So instead of writing 

```
expect($aDiv.find('button').length).toBe(2)
```

I can now write

```
expect($aDiv).toContainNumberOfElements(2, button)
```

The name of the function is somewhat long, but I find it's easier to see what I'm trying to test at a glance
