### PR TITLE
Return container from Fixture.set() & setFixture()

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -43,7 +43,7 @@ var appendLoadFixtures = function() {
 }
 
 var setFixtures = function(html) {
-  jasmine.getFixtures().proxyCallTo_('set', arguments)
+  return jasmine.getFixtures().proxyCallTo_('set', arguments)
 }
 
 var appendSetFixtures = function() {
@@ -106,7 +106,7 @@ jasmine.Fixtures = function() {
 
 jasmine.Fixtures.prototype.set = function(html) {
   this.cleanUp()
-  this.createContainer_(html)
+  return this.createContainer_(html)
 }
 
 jasmine.Fixtures.prototype.appendSet= function(html) {
@@ -155,6 +155,7 @@ jasmine.Fixtures.prototype.createContainer_ = function(html) {
     .attr('id', this.containerId)
     .html(html);
   $(document.body).append(container)
+  return container
 }
 
 jasmine.Fixtures.prototype.addToContainer_ = function(html){

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -229,15 +229,16 @@ describe("jasmine.Fixtures", function() {
       expect(fixturesContainer().html()).toEqual(jasmine.JQuery.browserTagCaseIndependentHtml(html))
     })
 
-    it("should have shortcut global method setFixtures", function() {
-      setFixtures(html)
-      expect(fixturesContainer().html()).toEqual(jasmine.JQuery.browserTagCaseIndependentHtml(html))
-    })
-
     describe("when fixture container does not exist", function() {
       it("should automatically create fixtures container and append it to DOM", function() {
         jasmine.getFixtures().set(html)
         expect(fixturesContainer().size()).toEqual(1)
+      })
+
+      it("should return the fixture container", function() {
+        var container = jasmine.getFixtures().set(html)
+        expect(container).toExist()
+        expect(container[0]).toEqual(fixturesContainer()[0])
       })
     })
 
@@ -250,8 +251,29 @@ describe("jasmine.Fixtures", function() {
         jasmine.getFixtures().set(html)
         expect(fixturesContainer().html()).toEqual(jasmine.JQuery.browserTagCaseIndependentHtml(html))
       })
+
+      it("should return the fixture container", function(){
+        var container = jasmine.getFixtures().set(html)
+        expect(container).toExist()
+        expect(container[0]).toEqual(fixturesContainer()[0])
+      })
     })
   })
+
+  describe("setFixtures", function() {
+    var html = '<div>some HTML</div>'
+
+    it("should be a shortcut global method", function() {
+      setFixtures(html)
+      expect(fixturesContainer().html()).toEqual(jasmine.JQuery.browserTagCaseIndependentHtml(html))
+    })
+
+    it("should return the fixture container", function() {
+      var container = setFixtures(html)
+      expect(container).toExist()
+      expect(container[0]).toEqual(fixturesContainer()[0])
+    })
+  });
 
   describe("appendSet",function(){
     var html = '<div>some HTML</div>'


### PR DESCRIPTION
We have added some syntax sugar which makes it easier to scope test selections to the fixture container. We can now do:

``` javascript
var fixture = setFixture('<div class="foo">foo</div>')
var foo = fixture.find('.foo')
```

Instead of:

``` javascript
setFixture('<div class="foo">foo</div>')
var foo = $('#' + jasmine.getFixture().containerId + ' .foo')
```

Or:

``` javascript
setFixture('<div class="foo">foo</div>')
var foo = $('.foo') //could conflict
```
