### PR TITLE
Add support for jQuery object equality

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -655,6 +655,18 @@ beforeEach(function() {
       return jasmine.JQuery.events.wasStopped(selector, eventName)
     }
   })
+  jasmine.getEnv().addEqualityTester(function(a, b) {
+    if(a instanceof jQuery && b instanceof jQuery) {
+      if(a.size() != b.size()) {
+        return jasmine.undefined;
+      }
+      else if(a.is(b)) {
+        return true;
+      }
+    }
+    return jasmine.undefined;
+    
+  })
 })
 
 afterEach(function() {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1667,4 +1667,41 @@ describe("jasmine.JSONFixtures using real AJAX call", function() {
   })
 })
 
+describe("jasmine.Env.equalityTesters_", function() {
+  describe("jQuery object tester", function() {
+    beforeEach(function() {
+      setFixtures(sandbox())
+    })
 
+    it("should equate the same element with different selectors", function() {
+      expect($('#sandbox')).toEqual($('div#sandbox'))
+    })
+
+    it("should equate jquery objects that match a set of elements", function() {
+      $('#sandbox').append($('<div></div>'))
+      $('#sandbox').append($('<div></div>'))
+      expect($('#sandbox div')).toEqual($('div#sandbox div'))
+    })
+
+    it("should not equate jquery objects that match a set of elements where one has an extra", function() {
+      $('#sandbox').append($('<div></div>'))
+      $('#sandbox').append($('<div></div>'))
+      $('#sandbox').append($('<span></span>'))
+      expect($('#sandbox div')).not.toEqual($('div#sandbox div, div#sandbox span'))
+    })
+
+    it("should not equate jquery objects that match a set of elements of the same type where the tag types are the same, but they are not the same DOM elements", function() {
+      $('#sandbox').append($('<div class="one"></div>'))
+      $('#sandbox').append($('<span class="one"></span>'))
+      $('#sandbox').append($('<div class="two"></div>'))
+      $('#sandbox').append($('<span class="two"></span>'))
+      expect($('.one')).not.toEqual($('.two').first())
+    })
+
+    it("should not equate jquery objects that match a set of elements of the same type where one is missing a single element", function() {
+      $('#sandbox').append($('<div></div>'))
+      $('#sandbox').append($('<div></div>'))
+      expect($('#sandbox div')).not.toEqual($('div#sandbox div').first())
+    })
+  })
+})


### PR DESCRIPTION
### I would like to see support for testing the equality of jquery objects.

Currently, asking jasmine if two jQuery objects are equal (through the function `jasmine.getEnv().equals_(object1, object2)`) will fail even if those jQuery objects are referencing the same DOM element.
This is annoying because it causes functions like `toHaveBeenCalledWith` to not work as expected when passing jQuery objects as arguments.
#### This pull request adds support for checking if two jQuery objects are equal. As a result, functions like `toHaveBeenCalledWith` will work as expected when passed jQuery objects.

To be clear, a jQuery object is typically something returned by `$('div')` 
For two jQuery objects to be equal means that:
- If objects with only one element are compared, both objects reference the same DOM element, even if they have different selectors
- If objects with many elements are compared, both objects reference the same set of elements, no more, no less
