### PR TITLE
Return cached JSON Fixtures on subsequent calls to getJSONFixture requesting the same fixture url.

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -219,7 +219,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   }
 
   jasmine.JSONFixtures.prototype.getFixtureData_ = function (url) {
-    this.loadFixtureIntoCache_(url)
+    if(! this.fixturesCache_[url]) {
+      this.loadFixtureIntoCache_(url)
+    }
     return this.fixturesCache_[url]
   }
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1643,7 +1643,15 @@ describe("jasmine.JSONFixtures", function () {
   describe('getJSONFixture', function () {
     it("fetches the fixture you ask for", function () {
       expect(getJSONFixture(fixtureUrl)).toEqual(ajaxData)
+      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_).toHaveBeenCalled()
       expect(getJSONFixture(anotherFixtureUrl)).toEqual(moreAjaxData)
+      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.length).toEqual(2)
+    })
+    it("retrieves from cache on subsequent requests for the same fixture", function () {
+      expect(getJSONFixture(fixtureUrl)).toEqual(ajaxData)
+      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.length).toEqual(1)
+      expect(getJSONFixture(fixtureUrl)).toEqual(ajaxData)
+      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.length).toEqual(1)
     })
   })
 


### PR DESCRIPTION
I may be missing the point, but there did not seem to be any way through the exposed methods to pull from the JSON fixture cache without re-loading the fixture first.

If preserving the current behavior of getJSONFixture() is desired, I can provide an alternate implementation under a different method name.

Thanks.
