### PR TITLE
Don't change the checked property of radio buttons

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -252,12 +252,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   }
 
   jasmine.JQuery.elementToString = function (element) {
-    var domEl = $(element).get(0)
-
-    if (domEl === undefined || domEl.cloneNode)
-      return $('<div />').append($(element).clone()).html()
-    else
-      return element.toString()
+    var htmlParts = $(element).map(function () { return this.outerHTML; }).toArray()
+    return htmlParts.join(', ')
   }
 
   jasmine.JQuery.matchersClass = {}

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -817,7 +817,8 @@ describe("jQuery matchers", function () {
     beforeEach(function () {
       setFixtures('\
         <input type="checkbox" id="checked" checked="checked" />\n\
-        <input type="checkbox" id="not-checked" />')
+        <input type="checkbox" id="not-checked" />\n\
+        <input type="radio" name="radio-name" id="radio-checked" checked="checked" />')
     })
 
     it("should pass on checked element", function () {
@@ -828,6 +829,11 @@ describe("jQuery matchers", function () {
     it("should pass negated on not checked element", function () {
       expect($('#not-checked')).not.toBeChecked()
       expect($('#not-checked').get(0)).not.toBeChecked()
+    })
+
+    it("shoud not change the checked status of a radio button", function () {
+      expect($('#radio-checked')).toBeChecked()
+      expect($('#radio-checked')).toBeChecked()
     })
   })
 


### PR DESCRIPTION
When cloning radio buttons to get the string value, some browsers such as
PhantomJS uncheck one of the radio buttons. Fix this by letting elementToString
use outerHTML instead of cloning to obtain the HTML.
