### PR TITLE
Compatibility with jasmine 2.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
       , options: {
           specs: "spec/**/*.js"
         , vendor: "vendor/**/*.js"
-        , version: '2.0.0-rc3'
+        , version: '2.0.0-rc5'
       }
     }
   })

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -255,8 +255,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     return $(element).map(function () { return this.outerHTML; }).toArray().join(', ')
   }
 
-  jasmine.JQuery.matchersClass = {}
-
   !function (namespace) {
     var data = {
         spiedEvents: {}
@@ -296,12 +294,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
       },
 
-      wasTriggeredWith: function (selector, eventName, expectedArgs, env) {
+      wasTriggeredWith: function (selector, eventName, expectedArgs, util, customEqualityTesters) {
         var actualArgs = jasmine.JQuery.events.args(selector, eventName).slice(1)
         if (Object.prototype.toString.call(expectedArgs) !== '[object Array]') {
           actualArgs = actualArgs[0]
         }
-        return env.equals_(expectedArgs, actualArgs)
+        return util.equals(expectedArgs, actualArgs, customEqualityTesters)
       },
 
       wasPrevented: function (selector, eventName) {
@@ -324,308 +322,384 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     }
   }(jasmine.JQuery)
 
-  !function (){
-    var jQueryMatchers = {
-      toHaveClass: function (className) {
-        return this.actual.hasClass(className)
+  var hasProperty = function (actualValue, expectedValue) {
+    if (expectedValue === undefined) return actualValue !== undefined
+
+    return actualValue == expectedValue
+  }
+
+  beforeEach(function () {
+    jasmine.addMatchers({
+      toHaveClass: function () {
+        return {
+          compare: function (actual, className) {
+            return { pass: $(actual).hasClass(className) }
+          }
+        }
       },
 
-      toHaveCss: function (css){
-        for (var prop in css){
-          var value = css[prop]
-          // see issue #147 on gh
-          ;if (value === 'auto' && this.actual.get(0).style[prop] === 'auto') continue
-          if (this.actual.css(prop) !== value) return false
+      toHaveCss: function () {
+        return {
+          compare: function (actual, css){
+            for (var prop in css){
+              var value = css[prop]
+              // see issue #147 on gh
+              ;if (value === 'auto' && $(actual).get(0).style[prop] === 'auto') continue
+                if ($(actual).css(prop) !== value) return { pass: false }
+            }
+            return { pass: true }
+          }
         }
-        return true
       },
 
       toBeVisible: function () {
-        return this.actual.is(':visible')
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':visible') }
+          }
+        }
       },
 
       toBeHidden: function () {
-        return this.actual.is(':hidden')
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':hidden') }
+          }
+        }
       },
 
       toBeSelected: function () {
-        return this.actual.is(':selected')
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':selected') }
+          }
+        }
       },
 
       toBeChecked: function () {
-        return this.actual.is(':checked')
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':checked') }
+          }
+        }
       },
 
       toBeEmpty: function () {
-        return this.actual.is(':empty')
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':empty') }
+          }
+        }
       },
 
       toExist: function () {
-        return this.actual.length
-      },
-
-      toHaveLength: function (length) {
-        return this.actual.length === length
-      },
-
-      toHaveAttr: function (attributeName, expectedAttributeValue) {
-        return hasProperty(this.actual.attr(attributeName), expectedAttributeValue)
-      },
-
-      toHaveProp: function (propertyName, expectedPropertyValue) {
-        return hasProperty(this.actual.prop(propertyName), expectedPropertyValue)
-      },
-
-      toHaveId: function (id) {
-        return this.actual.attr('id') == id
-      },
-
-      toHaveHtml: function (html) {
-        return this.actual.html() == jasmine.JQuery.browserTagCaseIndependentHtml(html)
-      },
-
-      toContainHtml: function (html){
-        var actualHtml = this.actual.html()
-          , expectedHtml = jasmine.JQuery.browserTagCaseIndependentHtml(html)
-
-        return (actualHtml.indexOf(expectedHtml) >= 0)
-      },
-
-      toHaveText: function (text) {
-        var trimmedText = $.trim(this.actual.text())
-
-        if (text && $.isFunction(text.test)) {
-          return text.test(trimmedText)
-        } else {
-          return trimmedText == text
-        }
-      },
-
-      toContainText: function (text) {
-        var trimmedText = $.trim(this.actual.text())
-
-        if (text && $.isFunction(text.test)) {
-          return text.test(trimmedText)
-        } else {
-          return trimmedText.indexOf(text) != -1
-        }
-      },
-
-      toHaveValue: function (value) {
-        return this.actual.val() === value
-      },
-
-      toHaveData: function (key, expectedValue) {
-        return hasProperty(this.actual.data(key), expectedValue)
-      },
-
-      toBe: function (selector) {
-        return this.actual.is(selector)
-      },
-
-      toContain: function (selector) {
-        return this.actual.find(selector).length
-      },
-
-      toBeMatchedBy: function (selector) {
-        return this.actual.filter(selector).length
-      },
-
-      toBeDisabled: function (selector){
-        return this.actual.is(':disabled')
-      },
-
-      toBeFocused: function (selector) {
-        return this.actual[0] === this.actual[0].ownerDocument.activeElement
-      },
-
-      toHandle: function (event) {
-        var events = $._data(this.actual.get(0), "events")
-
-        if(!events || !event || typeof event !== "string") {
-          return false
-        }
-
-        var namespaces = event.split(".")
-          , eventType = namespaces.shift()
-          , sortedNamespaces = namespaces.slice(0).sort()
-          , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)")
-
-        if(events[eventType] && namespaces.length) {
-          for(var i = 0; i < events[eventType].length; i++) {
-            var namespace = events[eventType][i].namespace
-
-            if(namespaceRegExp.test(namespace)) {
-              return true
-            }
-          }
-        } else {
-          return events[eventType] && events[eventType].length > 0
-        }
-      },
-
-      toHandleWith: function (eventName, eventHandler) {
-        var normalizedEventName = eventName.split('.')[0]
-          , stack = $._data(this.actual.get(0), "events")[normalizedEventName]
-
-        for (var i = 0; i < stack.length; i++) {
-          if (stack[i].handler == eventHandler) return true
-        }
-
-        return false
-      }
-    }
-
-    var hasProperty = function (actualValue, expectedValue) {
-      if (expectedValue === undefined) return actualValue !== undefined
-
-      return actualValue == expectedValue
-    }
-
-    var bindMatcher = function (methodName) {
-      var builtInMatcher = jasmine.Matchers.prototype[methodName]
-
-      jasmine.JQuery.matchersClass[methodName] = function () {
-        if (this.actual
-          && (this.actual instanceof $
-            || jasmine.isDomNode(this.actual))) {
-              this.actual = $(this.actual)
-              var result = jQueryMatchers[methodName].apply(this, arguments)
-                , element
-
-              if (this.actual.get && (element = this.actual.get()[0]) && !$.isWindow(element) && element.tagName !== "HTML")
-                this.actual = jasmine.JQuery.elementToString(this.actual)
-
-              return result
-            }
-
-            if (builtInMatcher) {
-              return builtInMatcher.apply(this, arguments)
-            }
-
-            return false
-      }
-    }
-
-    for(var methodName in jQueryMatchers) {
-      bindMatcher(methodName)
-    }
-  }()
-
-  beforeEach(function () {
-    this.addMatchers(jasmine.JQuery.matchersClass)
-    this.addMatchers({
-      toHaveBeenTriggeredOn: function (selector) {
-        this.message = function () {
-          return [
-            "Expected event " + this.actual + " to have been triggered on " + selector,
-            "Expected event " + this.actual + " not to have been triggered on " + selector
-          ]
-        }
-        return jasmine.JQuery.events.wasTriggered(selector, this.actual)
-      }
-    })
-    this.addMatchers({
-      toHaveBeenTriggered: function (){
-        var eventName = this.actual.eventName
-          , selector = this.actual.selector
-
-        this.message = function () {
-          return [
-            "Expected event " + eventName + " to have been triggered on " + selector,
-            "Expected event " + eventName + " not to have been triggered on " + selector
-          ]
-        }
-
-        return jasmine.JQuery.events.wasTriggered(selector, eventName)
-      }
-    })
-    this.addMatchers({
-      toHaveBeenTriggeredOnAndWith: function () {
-        var selector = arguments[0]
-          , expectedArgs = arguments[1]
-          , wasTriggered = jasmine.JQuery.events.wasTriggered(selector, this.actual)
-
-        this.message = function () {
-          if (wasTriggered) {
-            var actualArgs = jasmine.JQuery.events.args(selector, this.actual, expectedArgs)[1]
-            return [
-              "Expected event " + this.actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs),
-              "Expected event " + this.actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs)
-            ]
-          } else {
-            return [
-              "Expected event " + this.actual + " to have been triggered on " + selector,
-              "Expected event " + this.actual + " not to have been triggered on " + selector
-            ]
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).length }
           }
         }
+      },
 
-        return wasTriggered && jasmine.JQuery.events.wasTriggeredWith(selector, this.actual, expectedArgs, this.env)
-      }
-    })
-    this.addMatchers({
-      toHaveBeenPreventedOn: function (selector) {
-        this.message = function () {
-          return [
-            "Expected event " + this.actual + " to have been prevented on " + selector,
-            "Expected event " + this.actual + " not to have been prevented on " + selector
-          ]
+      toHaveLength: function () {
+        return {
+          compare: function (actual, length) {
+            return { pass: $(actual).length === length }
+          }
         }
+      },
 
-        return jasmine.JQuery.events.wasPrevented(selector, this.actual)
-      }
-    })
-    this.addMatchers({
+      toHaveAttr: function () {
+        return {
+          compare: function (actual, attributeName, expectedAttributeValue) {
+            return { pass: hasProperty($(actual).attr(attributeName), expectedAttributeValue) }
+          }
+        }
+      },
+
+      toHaveProp: function () {
+        return {
+          compare: function (actual, propertyName, expectedPropertyValue) {
+            return { pass: hasProperty($(actual).prop(propertyName), expectedPropertyValue) }
+          }
+        }
+      },
+
+      toHaveId: function () {
+        return {
+          compare: function (actual, id) {
+            return { pass: $(actual).attr('id') == id }
+          }
+        }
+      },
+
+      toHaveHtml: function () {
+        return {
+          compare: function (actual, html) {
+            return { pass: $(actual).html() == jasmine.JQuery.browserTagCaseIndependentHtml(html) }
+          }
+        }
+      },
+
+      toContainHtml: function () {
+        return {
+          compare: function (actual, html){
+            var actualHtml = $(actual).html()
+            , expectedHtml = jasmine.JQuery.browserTagCaseIndependentHtml(html)
+
+            return { pass: (actualHtml.indexOf(expectedHtml) >= 0) }
+          }
+        }
+      },
+
+      toHaveText: function () {
+        return {
+          compare: function (actual, text) {
+            var trimmedText = $.trim($(actual).text())
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(trimmedText) }
+            } else {
+              return { pass: trimmedText == text }
+            }
+          }
+        }
+      },
+
+      toContainText: function () {
+        return {
+          compare: function (actual, text) {
+            var trimmedText = $.trim($(actual).text())
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(trimmedText) }
+            } else {
+              return { pass: trimmedText.indexOf(text) != -1 }
+            }
+          }
+        }
+      },
+
+      toHaveValue: function () {
+        return {
+          compare: function (actual, value) {
+            return { pass: $(actual).val() === value }
+          }
+        }
+      },
+
+      toHaveData: function () {
+        return {
+          compare: function (actual, key, expectedValue) {
+            return { pass: hasProperty($(actual).data(key), expectedValue) }
+          }
+        }
+      },
+
+      toContainElement: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).find(selector).length }
+          }
+        }
+      },
+
+      toBeMatchedBy: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).filter(selector).length }
+          }
+        }
+      },
+
+      toBeDisabled: function () {
+        return {
+          compare: function (actual, selector){
+            return { pass: $(actual).is(':disabled') }
+          }
+        }
+      },
+
+      toBeFocused: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual)[0] === $(actual)[0].ownerDocument.activeElement }
+          }
+        }
+      },
+
+      toHandle: function () {
+        return {
+          compare: function (actual, event) {
+            var events = $._data($(actual).get(0), "events")
+
+            if(!events || !event || typeof event !== "string") {
+              return { pass: false }
+            }
+
+            var namespaces = event.split(".")
+            , eventType = namespaces.shift()
+            , sortedNamespaces = namespaces.slice(0).sort()
+            , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)")
+
+            if(events[eventType] && namespaces.length) {
+              for(var i = 0; i < events[eventType].length; i++) {
+                var namespace = events[eventType][i].namespace
+
+                if(namespaceRegExp.test(namespace)) {
+                  return { pass: true }
+                }
+              }
+            } else {
+              return { pass: events[eventType] && events[eventType].length > 0 }
+            }
+            return { pass: false }
+          }
+        }
+      },
+      toHandleWith: function () {
+        return {
+          compare: function (actual, eventName, eventHandler) {
+            var normalizedEventName = eventName.split('.')[0]
+            , stack = $._data($(actual).get(0), "events")[normalizedEventName]
+
+            for (var i = 0; i < stack.length; i++) {
+              if (stack[i].handler == eventHandler) return { pass: true }
+            }
+
+          return { pass: false }
+          }
+        }
+      },
+      toHaveBeenTriggeredOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.JQuery.events.wasTriggered(selector, actual) }
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been triggered on " + selector :
+              "Expected event " + actual + " to have been triggered on " + selector
+            return result
+          }
+        }
+      },
+      toHaveBeenTriggered: function () {
+        return {
+          compare: function (actual){
+            var eventName = actual.eventName
+            , selector = actual.selector
+            , result = { pass: jasmine.JQuery.events.wasTriggered(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been triggered on " + selector :
+              "Expected event " + eventName + " to have been triggered on " + selector
+
+            return result
+          }
+        }
+      },
+      toHaveBeenTriggeredOnAndWith: function (j$, customEqualityTesters) {
+        return {
+          compare: function (actual, selector, expectedArgs) {
+            var wasTriggered = jasmine.JQuery.events.wasTriggered(selector, actual)
+            , result = { pass: wasTriggered && jasmine.JQuery.events.wasTriggeredWith(selector, actual, expectedArgs, j$, customEqualityTesters) }
+            console.log(actual, selector, expectedArgs, wasTriggered, result)
+
+            if (wasTriggered) {
+              var actualArgs = jasmine.JQuery.events.args(selector, actual, expectedArgs)[1]
+              result.message = result.pass ?
+                "Expected event " + actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs) :
+                "Expected event " + actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs)
+            } else {
+              result.message = result.pass ?
+                "Expected event " + actual + " not to have been triggered on " + selector :
+                "Expected event " + actual + " to have been triggered on " + selector
+            }
+
+            return result
+          }
+        }
+      },
+      toHaveBeenPreventedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.JQuery.events.wasPrevented(selector, actual) }
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been prevented on " + selector :
+              "Expected event " + actual + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
       toHaveBeenPrevented: function () {
-        var eventName = this.actual.eventName
-          , selector = this.actual.selector
-        this.message = function () {
-          return [
-            "Expected event " + eventName + " to have been prevented on " + selector,
-            "Expected event " + eventName + " not to have been prevented on " + selector
-          ]
-        }
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+            , selector = actual.selector
+            , result = { pass: jasmine.JQuery.events.wasPrevented(selector, eventName) }
 
-        return jasmine.JQuery.events.wasPrevented(selector, eventName)
-      }
-    })
-    this.addMatchers({
-      toHaveBeenStoppedOn: function (selector) {
-        this.message = function () {
-          return [
-            "Expected event " + this.actual + " to have been stopped on " + selector,
-            "Expected event " + this.actual + " not to have been stopped on " + selector
-          ]
-        }
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been prevented on " + selector :
+              "Expected event " + eventName + " to have been prevented on " + selector
 
-        return jasmine.JQuery.events.wasStopped(selector, this.actual)
-      }
-    })
-    this.addMatchers({
+            return result
+          }
+        }
+      },
+      toHaveBeenStoppedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.JQuery.events.wasStopped(selector, actual) }
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been stopped on " + selector :
+              "Expected event " + actual + " to have been stopped on " + selector
+
+            return result
+          }
+        }
+      },
       toHaveBeenStopped: function () {
-        var eventName = this.actual.eventName
-          , selector = this.actual.selector
-        this.message = function () {
-          return [
-            "Expected event " + eventName + " to have been stopped on " + selector,
-            "Expected event " + eventName + " not to have been stopped on " + selector
-          ]
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+            , selector = actual.selector
+            , result = { pass: jasmine.JQuery.events.wasStopped(selector, eventName) }
+
+            result.message = result.pass ?
+                "Expected event " + eventName + " not to have been stopped on " + selector :
+                "Expected event " + eventName + " to have been stopped on " + selector
+
+            return result
+          }
         }
-        return jasmine.JQuery.events.wasStopped(selector, eventName)
+      },
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function(a, b) {
+      if (a && b) {
+        if (a instanceof jQuery || jasmine.isDomNode(a)) {
+          var $a = $(a)
+          if (b instanceof jQuery) {
+            return $a.length == b.length && a.is(b)
+          }
+          return $a.is(b);
+        }
+
+        if (b instanceof jQuery || jasmine.isDomNode(b)) {
+          var $b = $(b)
+          if (a instanceof jQuery) {
+            return a.length == $b.length && $b.is(a)
+          }
+          return $(b).is(a);
+        }
       }
     })
-    jasmine.getEnv().addEqualityTester(function (a, b) {
+
+    jasmine.getEnv().addCustomEqualityTester(function (a, b) {
       if(a instanceof jQuery && b instanceof jQuery) {
-        if(a.size() != b.size()) {
-          return jasmine.undefined
-        }
-        else if(a.is(b)) {
-          return true
+        if(a.size() == b.size()) {
+          return a.is(b);
         }
       }
-
-      return jasmine.undefined
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   , "devDependencies": {
       "grunt": "~0.4.1"
     , "grunt-contrib-jshint": "~0.6.0"
-    , "grunt-contrib-jasmine": "git://github.com/travisjeffery/grunt-contrib-jasmine#a78d1cd558fd72a8deffb8f9e4224cfa40f97cc9"
+    , "grunt-contrib-jasmine": "git://github.com/travisjeffery/grunt-contrib-jasmine#fa720365d48a04befe058666cd683ca2bdee1e6f"
   }
 }

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -11,7 +11,7 @@ describe("jasmine.Fixtures", function () {
 
   beforeEach(function () {
     jasmine.getFixtures().clearCache()
-    spyOn(jasmine.Fixtures.prototype, 'loadFixtureIntoCache_').andCallFake(function (relativeUrl){
+    spyOn(jasmine.Fixtures.prototype, 'loadFixtureIntoCache_').and.callFake(function (relativeUrl){
       this.fixturesCache_[relativeUrl] = ajaxData
     })
   })
@@ -32,18 +32,18 @@ describe("jasmine.Fixtures", function () {
         jasmine.getFixtures().read(fixtureUrl)
         jasmine.getFixtures().clearCache()
         jasmine.getFixtures().read(fixtureUrl)
-        expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(2)
+        expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(2)
       })
     })
 
     it("first-time read should go through AJAX", function () {
       jasmine.getFixtures().read(fixtureUrl)
-      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(1)
+      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(1)
     })
 
     it("subsequent read from the same URL should go from cache", function () {
       jasmine.getFixtures().read(fixtureUrl, fixtureUrl)
-      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(1)
+      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(1)
     })
   })
 
@@ -194,7 +194,7 @@ describe("jasmine.Fixtures", function () {
       it("should go from cache", function () {
         jasmine.getFixtures().preload(fixtureUrl, anotherFixtureUrl)
         jasmine.getFixtures().read(fixtureUrl, anotherFixtureUrl)
-        expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(2)
+        expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(2)
       })
 
       it("should return correct HTMLs", function () {
@@ -206,13 +206,13 @@ describe("jasmine.Fixtures", function () {
 
     it("should not preload the same fixture twice", function () {
       jasmine.getFixtures().preload(fixtureUrl, fixtureUrl)
-      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(1)
+      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(1)
     })
 
     it("should have shortcut global method preloadFixtures", function () {
       preloadFixtures(fixtureUrl, anotherFixtureUrl)
       jasmine.getFixtures().read(fixtureUrl, anotherFixtureUrl)
-      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(2)
+      expect(jasmine.Fixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(2)
     })
   })
 
@@ -403,22 +403,16 @@ describe("jasmine.Fixtures using real AJAX call", function () {
 
 
 describe("jQuery matchers", function () {
-  describe("when jQuery matcher hides original Jasmine matcher", function () {
+  describe("custom jquery object equality tester", function () {
     describe("and tested item is jQuery object", function () {
-      it("should invoke jQuery version of matcher", function () {
-        expect($('<div />')).toBe('div')
-      })
-    })
-
-    describe("and tested item is not jQuery object", function () {
-      it("should invoke original version of matcher", function () {
-        expect(true).toBe(true)
+      it("should do jquery equality", function () {
+        expect($('<div />')).toEqual('div')
       })
     })
 
     describe("and tested item is a dom object", function () {
-      it("should invoke jquery version of matcher", function () {
-        expect($('<div />').get(0)).toBe('div')
+      it("should do jquery equality", function () {
+        expect($('<div />').get(0)).toEqual('div')
       })
     })
   })
@@ -568,7 +562,7 @@ describe("jQuery matchers", function () {
       $("#sandbox").css("height", "auto");
       $("#sandbox").css("margin-left", "auto");
       $("#sandbox").css("display", "none");
-      expect($("#sandbox")).toHaveCss({height: 'auto', 'margin-left': "0px", display: "none"});
+      expect($("#sandbox")).toHaveCss({height: 'auto', 'margin-left': "auto", display: "none"});
     })
   })
 
@@ -901,35 +895,19 @@ describe("jQuery matchers", function () {
     })
   })
 
-  describe("toBe", function () {
-    beforeEach(function () {
-      setFixtures(sandbox())
-    })
-
-    it("should pass if object matches selector", function () {
-      expect($('#sandbox')).toBe('#sandbox')
-      expect($('#sandbox').get(0)).toBe('#sandbox')
-    })
-
-    it("should pass negated if object does not match selector", function () {
-      expect($('#sandbox')).not.toBe('#wrong-id')
-      expect($('#sandbox').get(0)).not.toBe('#wrong-id')
-    })
-  })
-
-  describe("toContain", function () {
+  describe("toContainElement", function () {
     beforeEach(function () {
       setFixtures(sandbox().html('<span />'))
     })
 
     it("should pass if object contains selector", function () {
-      expect($('#sandbox')).toContain('span')
-      expect($('#sandbox').get(0)).toContain('span')
+      expect($('#sandbox')).toContainElement('span')
+      expect($('#sandbox').get(0)).toContainElement('span')
     })
 
     it("should pass negated if object does not contain selector", function () {
-      expect($('#sandbox')).not.toContain('div')
-      expect($('#sandbox').get(0)).not.toContain('div')
+      expect($('#sandbox')).not.toContainElement('div')
+      expect($('#sandbox').get(0)).not.toContainElement('div')
     })
   })
 
@@ -1384,7 +1362,7 @@ describe("jasmine.StyleFixtures", function () {
 
   beforeEach(function () {
     jasmine.getStyleFixtures().clearCache()
-    spyOn(jasmine.StyleFixtures.prototype, 'loadFixtureIntoCache_').andCallFake(function (relativeUrl){
+    spyOn(jasmine.StyleFixtures.prototype, 'loadFixtureIntoCache_').and.callFake(function (relativeUrl){
       this.fixturesCache_[relativeUrl] = ajaxData
     })
   })
@@ -1470,7 +1448,7 @@ describe("jasmine.StyleFixtures", function () {
       it("should go from cache", function () {
         jasmine.getStyleFixtures().preload(fixtureUrl, anotherFixtureUrl)
         jasmine.getStyleFixtures().load(fixtureUrl, anotherFixtureUrl)
-        expect(jasmine.StyleFixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(2)
+        expect(jasmine.StyleFixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(2)
       })
 
       it("should return correct CSSs", function () {
@@ -1482,12 +1460,12 @@ describe("jasmine.StyleFixtures", function () {
 
     it("should not preload the same fixture twice", function () {
       jasmine.getStyleFixtures().preload(fixtureUrl, fixtureUrl)
-      expect(jasmine.StyleFixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(1)
+      expect(jasmine.StyleFixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(1)
     })
 
     it("should have shortcut global method preloadStyleFixtures", function () {
       preloadStyleFixtures(fixtureUrl, anotherFixtureUrl)
-      expect(jasmine.StyleFixtures.prototype.loadFixtureIntoCache_.callCount).toEqual(2)
+      expect(jasmine.StyleFixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(2)
     })
   })
 
@@ -1604,7 +1582,7 @@ describe("jasmine.JSONFixtures", function () {
 
   beforeEach(function () {
     jasmine.getJSONFixtures().clearCache()
-    spyOn(jasmine.JSONFixtures.prototype, 'loadFixtureIntoCache_').andCallFake(function (relativeUrl){
+    spyOn(jasmine.JSONFixtures.prototype, 'loadFixtureIntoCache_').and.callFake(function (relativeUrl){
       fakeData = {}
       // we put the data directly here, instead of using the variables to simulate rereading the file
       fakeData[fixtureUrl] = {a:1, b:2, arr: [1,2,'stuff'], hsh: { blurp: 8, blop: 'blip' }}
@@ -1651,14 +1629,14 @@ describe("jasmine.JSONFixtures", function () {
       expect(getJSONFixture(fixtureUrl)).toEqual(ajaxData)
       expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_).toHaveBeenCalled()
       expect(getJSONFixture(anotherFixtureUrl)).toEqual(moreAjaxData)
-      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.length).toEqual(2)
+      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(2)
     })
 
     it("retrieves from cache on subsequent requests for the same fixture", function () {
       expect(getJSONFixture(fixtureUrl)).toEqual(ajaxData)
-      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.length).toEqual(1)
+      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(1)
       expect(getJSONFixture(fixtureUrl)).toEqual(ajaxData)
-      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.length).toEqual(1)
+      expect(jasmine.JSONFixtures.prototype.loadFixtureIntoCache_.calls.count()).toEqual(1)
     })
   })
 


### PR DESCRIPTION
- Jasmine 2.0 doesn't allow you to grab the existing matcher and
  override it, so the matchers that did that had to be re-worked.
- toBe is now a customEqualityTester so:
  - toBe($('.foo'))
    becomes:
  - toEqual($('.foo'))
- toContain was renamed to toContainElement
