### PR TITLE
Fix quotation in jQuery matchers examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ jasmine-jquery provides following custom matchers (in alphabetical order):
 - `toHaveLength(value)`
   - e.g. `expect($('ul > li')).toHaveLength(3)`
 - `toBeDisabled()`
-  - e.g. `expect('<input type='submit' disabled='disabled'/>').toBeDisabled()`
+  - e.g. `expect('<input type="submit" disabled="disabled" />').toBeDisabled()`
 - `toBeFocused()`
-  - e.g. `expect($('<input type='text' />').focus()).toBeFocused()`
+  - e.g. `expect($('<input type="text" />').focus()).toBeFocused()`
 - `toHandle(eventName)`
   - e.g. `expect($form).toHandle("submit")`
 - `toHandleWith(eventName, eventHandler)`


### PR DESCRIPTION
Using single quotes in the `expect()` function while using single quotes for the HTML attributes will not work.
