### PR TITLE
Use global jQuery in this.actual instance check

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -487,7 +487,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       jasmine.JQuery.matchersClass[methodName] = function () {
         if (this.actual
-          && (this.actual instanceof $
+          && (this.actual instanceof jQuery
             || jasmine.isDomNode(this.actual))) {
               this.actual = $(this.actual)
               var result = jQueryMatchers[methodName].apply(this, arguments)


### PR DESCRIPTION
Here's the thing.

I spent at leat evening with that case. I have two jQuery scripts on the same page. They go in following order:

```
tests/jquery-1.9.1.js
tests/jasmine-jquery.js
app/jquery-1.9.1.js
specs/testSpec.js
```

So local `$` in jasmine-jquery is first script instance, but in specs I got second instance. I know that I doing it wrong, because there may be different jQuery versions, but I think that using global `$` only in instance check it is convenient compromise. Moreover, in `addEqualityTester` you have `a instanceof jQuery` rather than `a instanceof $`, so you should choose only one way.
