### PR TITLE
Adding toBeInDOM and tests

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -357,6 +357,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       return this.actual.is(':empty')
     },
 
+    toBeInDOM: function () {
+      return this.actual.closest(document.body).length
+    },
+
     toExist: function () {
       return this.actual.length
     },
@@ -698,3 +702,4 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url]
   }
 }(window.jasmine, window.jQuery);
+

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -883,6 +883,17 @@ describe("jQuery matchers", function () {
     })
   })
 
+  describe("toBeInDOM", function () {
+    it("should pass on elements in the DOM", function () {
+      setFixtures(sandbox())
+      expect($('#sandbox')).toBeInDOM()
+    })
+
+    it("should pass negated on elements not in the DOM", function () {
+      expect($('<div>')).not.toBeInDOM()
+    })
+  })
+
   describe("toExist", function () {
     it("should pass on visible element", function () {
       setFixtures(sandbox())


### PR DESCRIPTION
Now that toExist no longer checks presence in the DOM, this matcher fills that gap.

I tried to run tests but couldn't get `grunt` to work properly.
