### PR TITLE
Match if the surrounding whitespace in the input matches the element text

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -393,12 +393,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     toHaveText: function (text) {
-      var trimmedText = $.trim(this.actual.text())
+      var actualText = this.actual.text()
+      var trimmedText = $.trim(actualText)
 
       if (text && $.isFunction(text.test)) {
-        return text.test(trimmedText)
+        return text.test(actualText) || text.test(trimmedText)
       } else {
-        return trimmedText == text
+        return actualText == text || trimmedText == text
       }
     },
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -643,9 +643,15 @@ describe("jQuery matchers", function () {
       expect(element.get(0)).toHaveText(text)
     })
 
-    it("should ignore surrounding whitespace", function () {
+    it("should ignore surrounding whitespace in the element", function () {
       element = $('<div>\n' + text + '\n</div>')
       expect(element).toHaveText(text)
+      expect(element.get(0)).toHaveText(text)
+    })
+
+    it("should match with surrounding whitespace in the input", function () {
+      element = $('<div>\n' + text + '\n</div>')
+      expect(element).toHaveText('\n' + text + '\n')
       expect(element.get(0)).toHaveText(text)
     })
 


### PR DESCRIPTION
Currently the text in the element is trimmed before comparing. This is helpful
in some cases, but we're unable to match intentional surrounding whitespace.

For instance, given an element like this:

``` html
<div> foo</div>
```

The following matcher will always fail:

``` javascript
expect($div).toHaveText(' foo');
```

This fixes that case so that the matcher passes if the surrounding whitespace
in the input matches the surrounding whitespace in the element text exactly.
