### PR TITLE
Update fixture to ignore script tag without src attribute

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -132,7 +132,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           throw new Error('Fixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + errorThrown.message + ')')
       })
 
-      var scripts = $($.parseHTML(htmlText, true)).find('script') || [];
+      var scripts = $($.parseHTML(htmlText, true)).find('script[src]') || [];
 
       scripts.each(function(){
         $.ajax({

--- a/spec/fixtures/fixture_with_javascript_block.html
+++ b/spec/fixtures/fixture_with_javascript_block.html
@@ -1,0 +1,1 @@
+<div id="anchor_01"><script type="text/template">{{name}</script></div>

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -416,6 +416,15 @@ describe("jasmine.Fixtures using real AJAX call", function () {
       expect($("#anchor_01")).toHaveClass('bar')
     })
   })
+
+  describe("when fixture contains a <script> tag without a src attribute", function () {
+    var fixtureUrl = "fixture_with_javascript_block.html"
+
+    it("should load the fixture and ignore the script tag", function () {
+      jasmine.getFixtures().load(fixtureUrl)
+      expect($("#anchor_01").length).toBe(1)
+    })
+  })
 })
 
 describe("jQuery matcher", function () {


### PR DESCRIPTION
I was using jasmine-jquery to help test the jquery.cycle2.js plugin and it uses `<script>` tags to contain template data. jasmine-jquery was trying to use ajax to load the `src` attribute of the `<script>` tag, but in this case I didn't want that. I updated the code to only look for `<script>` tags with the `src` attribute. I added a unit test that fails without the fix and passes with the fix. Thank you for your helpful library.
