### PR TITLE
Fixed how jasmine gets loaded through jasmine gem

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -29,8 +29,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ;(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jasmine', 'jquery'], function(jasmine, $) {
-      factory(root, jasmine, $)
+    var requirements = ['jquery'];
+    if(!window.jasmine) requirements.push('jasmine');
+    define(requirements, function($) {
+      factory(root, window.jasmine || require('jasmine'), $)
     })
   } else {
     factory(root, root.jasmine, root.jQuery)


### PR DESCRIPTION
This still doesn't fix the problem, but it appropriately loads dependencies based on availability
