### PR TITLE
patch `toHandle` and `toHandleWidth` to properly handle actuals that don't match to any elements

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -559,7 +559,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       toHandle: function () {
         return {
           compare: function (actual, event) {
-            if ( !actual ) return { pass: false };
+            if ( !actual || actual.length === 0 ) return { pass: false };
             var events = $._data($(actual).get(0), "events")
 
             if (!events || !event || typeof event !== "string") {
@@ -590,7 +590,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       toHandleWith: function () {
         return {
           compare: function (actual, eventName, eventHandler) {
-            if ( !actual ) return { pass: false };
+            if ( !actual || actual.length === 0 ) return { pass: false };
             var normalizedEventName = eventName.split('.')[0]
               , stack = $._data($(actual).get(0), "events")[normalizedEventName]
 

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -559,6 +559,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       toHandle: function () {
         return {
           compare: function (actual, event) {
+            if ( !actual ) return { pass: false };
             var events = $._data($(actual).get(0), "events")
 
             if (!events || !event || typeof event !== "string") {
@@ -589,6 +590,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       toHandleWith: function () {
         return {
           compare: function (actual, eventName, eventHandler) {
+            if ( !actual ) return { pass: false };
             var normalizedEventName = eventName.split('.')[0]
               , stack = $._data($(actual).get(0), "events")[normalizedEventName]
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1332,6 +1332,11 @@ describe("jQuery matcher", function () {
       $(object).bind('click', function (){})
       expect($(object)).toHandle('click')
     })
+
+    it('should not fail when actual has no matches', function (){
+      expect($('#notreal')).not.toHandle('click')
+    })
+
   })
 
   describe('toHandleWith', function () {
@@ -1406,6 +1411,11 @@ describe("jQuery matcher", function () {
       $(object).bind('click.namespaced', handler)
       expect($(object)).toHandleWith('click.namespaced', handler)
     })
+
+    it('should not fail when actual has no matches', function (){
+      expect($('#notreal')).not.toHandleWith('click')
+    })
+
   })
 })
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1334,7 +1334,11 @@ describe("jQuery matcher", function () {
     })
 
     it('should not fail when actual has no matches', function (){
-      expect($('#notreal')).not.toHandle('click')
+        expect($('#notreal')).not.toHandle('click')
+    })
+
+    it('should not fail when actual is null', function (){
+        expect(null).not.toHandle('click')
     })
 
   })
@@ -1414,6 +1418,10 @@ describe("jQuery matcher", function () {
 
     it('should not fail when actual has no matches', function (){
       expect($('#notreal')).not.toHandleWith('click')
+    })
+
+    it('should not fail when actual is null', function (){
+      expect(null).not.toHandleWith('click')
     })
 
   })


### PR DESCRIPTION
I noticed while upgrading my tests that these were giving nodeType errors, so here's my attempt at fixing. Let me know if I need to make any other changes to make it palatable for pulling. :)