### PR TITLE
Event Spies: Added functions to check call counts

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -283,7 +283,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   jasmine.jQuery.events = {
     spyOn: function (selector, eventName) {
       var handler = function (e) {
-        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = jasmine.util.argsToArray(arguments)
+        var thisEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)];
+          (typeof thisEvent === 'undefined') ?
+              data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+                  args: jasmine.util.argsToArray(arguments),
+                  calls: 1
+              } :
+              thisEvent.calls++;
       }
 
       $(selector).on(eventName, handler)
@@ -295,12 +301,20 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         handler: handler,
         reset: function (){
           delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        },
+        calls: {
+            count: function () {
+                return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls;
+            },
+            any: function () {
+                return !!data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls;
+            }
         }
       }
     },
 
     args: function (selector, eventName) {
-      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]['args']
 
       if (!actualArgs) {
         throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
@@ -323,14 +337,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     wasPrevented: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]['args']
         , e = args ? args[0] : undefined
 
       return e && e.isDefaultPrevented()
     },
 
     wasStopped: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]['args']
         , e = args ? args[0] : undefined
       return e && e.isPropagationStopped()
     },

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -283,13 +283,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   jasmine.jQuery.events = {
     spyOn: function (selector, eventName) {
       var handler = function (e) {
-        var thisEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)];
-          (typeof thisEvent === 'undefined') ?
-              data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
-                  args: jasmine.util.argsToArray(arguments),
-                  calls: 1
-              } :
-              thisEvent.calls++;
+        var calls;
+          (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] === 'undefined') ? calls++ : calls = 1;
+          data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+              args: jasmine.util.argsToArray(arguments),
+              calls: calls
+          }
       }
 
       $(selector).on(eventName, handler)
@@ -346,6 +345,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     wasStopped: function (selector, eventName) {
       var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
         , e = args ? args[0] : undefined
+
       return e && e.isPropagationStopped()
     },
 

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -283,12 +283,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   jasmine.jQuery.events = {
     spyOn: function (selector, eventName) {
       var handler = function (e) {
-        var calls;
-          (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] === 'undefined') ? calls++ : calls = 1;
-          data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
-              args: jasmine.util.argsToArray(arguments),
-              calls: calls
-          }
+        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+          args: jasmine.util.argsToArray(arguments),
+          calls: ++calls
+        }
       }
 
       $(selector).on(eventName, handler)
@@ -336,14 +335,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     wasPrevented: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
         , e = args ? args[0] : undefined
 
       return e && e.isDefaultPrevented()
     },
 
     wasStopped: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
         , e = args ? args[0] : undefined
 
       return e && e.isPropagationStopped()

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -314,7 +314,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     args: function (selector, eventName) {
-      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]['args']
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
 
       if (!actualArgs) {
         throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
@@ -337,14 +337,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     wasPrevented: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]['args']
+      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
         , e = args ? args[0] : undefined
 
       return e && e.isDefaultPrevented()
     },
 
     wasStopped: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]['args']
+      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
         , e = args ? args[0] : undefined
       return e && e.isPropagationStopped()
     },


### PR DESCRIPTION
Jasmine equivalents:
`.calls.any()`
http://jasmine.github.io/2.0/introduction.html#section-23

`.calls.count()`
http://jasmine.github.io/2.0/introduction.html#section-24

Example tests:

    var spyEvent = spyOnEvent('#some_element', 'click');

    // Passing
    expect(spyEvent.calls.any()).toEqual(false);
    $('#some_element').click();
    expect(spyEvent.calls.count()).toEqual(1);

    // Failing
    expect(spyEvent.calls.any().toEqual(false);
    expect(spyEvent.calls.count()).toEqual(0);