### PR TITLE
Use jQuery 1.4+ as dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "SpecRunner.html"
   ],
   "dependencies": {
-    "jasmine": ">=2",
+    "jasmine": ">=1.4",
     "jquery": ">=2"
   }
 }


### PR DESCRIPTION
This commit changes the version of jQuery defined in bower.json to support older version as 2.x.

We currently get a conflict within our project when using jQuery v1.11.
When installing via `bower i` there is a message where you have to manually choose which version to use. For automated installers (as for example when running on Jenkins) you need to define a resolution in `bower.json` in order to prevent a build failure.

With this path everyone who used jasmin-jquery and jquery can use jQuery v1.4 or newer. I don't know if this might cause errors with jasmine-jquery's functionality.
