### PR TITLE
Only show inner text on failure of toContainText matcher

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -403,7 +403,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     toContainText: function (text) {
-      var trimmedText = $.trim(this.actual.text())
+      var trimmedText = this.actual.text().replace(/(\r\n|\n|\r)/gm, "")
+
+      this.message = function () {
+        return [
+          "Expected " + trimmedText + " \nto contain \n'" + text + "'",
+          "Expected " + trimmedText + " \nnot to contain \n'" + text + "'"
+        ]
+      }
 
       if (text && $.isFunction(text.test)) {
         return text.test(trimmedText)


### PR DESCRIPTION
This is for `1.7.x`. I can also submit another one for master if you would like.

The old output included the entire DOM structure which made it hard to parse
