### PR TITLE
Fix order of arguments to util.equals in wasTriggeredWith.

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -319,7 +319,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       if (Object.prototype.toString.call(expectedArgs) !== '[object Array]')
         actualArgs = actualArgs[0]
 
-      return util.equals(expectedArgs, actualArgs, customEqualityTesters)
+      return util.equals(actualArgs, expectedArgs, customEqualityTesters)
     },
 
     wasPrevented: function (selector, eventName) {

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1090,6 +1090,11 @@ describe("jQuery matcher", function () {
         $(document).trigger('event', { different_key: "value1" })
         expect('event').not.toHaveBeenTriggeredOnAndWith(document, { key1: "value1" })
       })
+
+      it('should pass if the arguments match using jasmine.objectContaining', function () {
+        $(document).trigger('event', { key1: "value1", key2: "value2" })
+        expect('event').toHaveBeenTriggeredOnAndWith(document, jasmine.objectContaining({ key1: "value1" }))
+      })
     })
 
     describe("when extra parameter is an array", function () {


### PR DESCRIPTION
This was preventing jasmine.objectContaining to be used in toHaveBeenTriggeredOnAndWith.