### PR TITLE
Break up script tags to allow inline use

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -141,7 +141,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             dataType: 'script',
             url: $(this).attr('src'),
             success: function (data, status, $xhr) {
-                htmlText += '<script>' + $xhr.responseText + '</script>'
+                htmlText += '<scr'+'ipt>' + $xhr.responseText + '</scr'+'ipt>'
             },
             error: function ($xhr, status, err) {
                 throw new Error('Script could not be loaded: ' + scriptSrc + ' (status: ' + status + ', message: ' + err.message + ')')


### PR DESCRIPTION
Breaking up the closing <script> tag allows jasmine-query.js to be included inline in a script tag: A closing script tag would cause the browser to believe the script has come to an end.

I have a situation where I couldn't load it externally and it broke my test suite.