### PR TITLE
Added the call count functions found in jasmine

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -284,7 +284,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   jasmine.jQuery.events = {
     spyOn: function (selector, eventName) {
       var handler = function (e) {
-        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = jasmine.util.argsToArray(arguments)
+        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+          args: jasmine.util.argsToArray(arguments),
+          calls: ++calls
+        }
       }
 
       $(selector).on(eventName, handler)
@@ -296,12 +300,22 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         handler: handler,
         reset: function (){
           delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        },
+        calls: {
+          count: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0;
+          },
+          any: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                !!data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : false;
+          }
         }
       }
     },
 
     args: function (selector, eventName) {
-      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
 
       if (!actualArgs) {
         throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
@@ -324,15 +338,18 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     wasPrevented: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
         , e = args ? args[0] : undefined
 
       return e && e.isDefaultPrevented()
     },
 
     wasStopped: function (selector, eventName) {
-      var args = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
         , e = args ? args[0] : undefined
+
       return e && e.isPropagationStopped()
     },
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1032,9 +1032,10 @@ describe("jQuery matcher", function () {
   })
 
   describe('toHaveBeenTriggeredOn', function () {
+    var spyEvents = {}
     beforeEach(function () {
       setFixtures(sandbox().html('<a id="clickme">Click Me</a> <a id="otherlink">Other Link</a>'))
-      spyOnEvent($('#clickme'), 'click')
+      spyEvents['#clickme'] = spyOnEvent($('#clickme'), 'click')
       spyOnEvent(document, 'click')
       spyOnEvent($('#otherlink'), 'click')
     })
@@ -1066,6 +1067,20 @@ describe("jQuery matcher", function () {
       $('#otherlink').click()
       expect('click').not.toHaveBeenTriggeredOn($('#clickme'))
       expect('click').not.toHaveBeenTriggeredOn('#clickme')
+    })
+
+    it('should pass if the event call count is incremented', function () {
+      expect(spyEvents['#clickme'].calls.any()).toEqual(false);
+      expect(spyEvents['#clickme'].calls.count()).toEqual(0);
+      $('#clickme').click()
+      expect('click').toHaveBeenTriggeredOn($('#clickme'))
+      expect('click').toHaveBeenTriggeredOn('#clickme')
+      expect(spyEvents['#clickme'].calls.count()).toEqual(1);
+      expect(spyEvents['#clickme'].calls.any()).toEqual(true);
+      $('#clickme').click()
+      $('#clickme').click()
+      expect(spyEvents['#clickme'].calls.count()).toEqual(3);
+      expect(spyEvents['#clickme'].calls.any()).toEqual(true);
     })
   })
 
@@ -1163,6 +1178,19 @@ describe("jQuery matcher", function () {
       expect('click').not.toHaveBeenTriggeredOn($('#clickme'))
       expect('click').not.toHaveBeenTriggeredOn('#clickme')
       expect(spyEvents['#clickme']).not.toHaveBeenTriggered()
+    })
+
+    it('should pass if the event call count is incremented', function () {
+      expect(spyEvents['#clickme'].calls.any()).toEqual(false);
+      expect(spyEvents['#clickme'].calls.count()).toEqual(0);
+      $('#clickme').click()
+      expect(spyEvents['#clickme']).toHaveBeenTriggered()
+      expect(spyEvents['#clickme'].calls.count()).toEqual(1);
+      expect(spyEvents['#clickme'].calls.any()).toEqual(true);
+      $('#clickme').click()
+      $('#clickme').click()
+      expect(spyEvents['#clickme'].calls.count()).toEqual(3);
+      expect(spyEvents['#clickme'].calls.any()).toEqual(true);
     })
   })
 


### PR DESCRIPTION
This PR adds the `calls.count()` and `calls.any()` found in Jasmine http://jasmine.github.io/2.2/introduction.html#section-Other_tracking_properties.

This is essentially https://github.com/velesin/jasmine-jquery/pull/195 rebased on master with some added specs.

Closes #195.
Partially address #225.
Partially address #136.