### PR TITLE
Added better CSS matcher failure message

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -383,7 +383,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
               var value = css[prop]
               // see issue #147 on gh
               ;if (value === 'auto' && $(actual).get(0).style[prop] === 'auto') continue
-              if ($(actual).css(prop) !== value) return { pass: false }
+              if ($(actual).css(prop) !== value) return {
+                pass: false
+                message: "Expected " +
+                  actual.tagName.toLowerCase() + "." + actual.className.split(" ").join(".") + " " +
+                  "to have " + prop + ":" + value + ", " +
+                  "instead was " + prop + ":" + $(actual).css(prop)
+              }
             }
             return { pass: true }
           }


### PR DESCRIPTION
It's hard to debug when a test that fails with invalid CSS, since there is no actual/expected message associated with the failure.