### PR TITLE
Ensure that CSS read from a URL will be appended into the head element:

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -198,9 +198,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
   jasmine.StyleFixtures.prototype.createStyle_ = function (html) {
     var styleText = $('<div></div>').html(html).text()
-      , style = $('<style>' + styleText + '</style>')
+      , style = '<style>' + styleText + '</style>'
 
-    this.fixturesNodes_.push(style)
+    this.fixturesNodes_.push($(style))
     $('head').append(style)
   }
 


### PR DESCRIPTION
- When loading CSS data, we now only appends the style element containing the
  CSS data to the head element.

- Previously we were attempting to append into the head element a jQuery
  object instance of the CSS data. This worked fine with CSS strings from set().
  However, nothing was being appended in the case of CSS data read from a
  URL (using an ajax request), i.e. using method load(). 
  (Possibly because responseText was returning a DOMString, which although is mapped to a String in
  javascript, may be handled differently as compared to a String when transformed into a jQuery Object.) 