### PR TITLE
add $expect() as a shortcut for expect($(...))

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # jasmine-jquery [![Build Status](https://travis-ci.org/velesin/jasmine-jquery.png)](https://travis-ci.org/velesin/jasmine-jquery)
 
 
-jasmine-jquery provides two extensions for the [Jasmine](http://jasmine.github.io/) JavaScript Testing Framework:
+jasmine-jquery provides three extensions for the [Jasmine](http://jasmine.github.io/) JavaScript Testing Framework:
 
 - a set of custom matchers for jQuery framework
 - an API for handling HTML, CSS, and JSON fixtures in your specs
+- the function `$expect(selector)`, which is a simple shortcut for `expect( $( selector )  )`.
 
 ## Installation
 

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -829,4 +829,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   window.getJSONFixture = function (url) {
     return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url]
   }
+
+  window.$expect = function( selector ) {
+      return window.expect( $(selector) )
+  }
+
 }(window, window.jasmine, window.jQuery);


### PR DESCRIPTION
Not a huge thing, but nicely minimize the visual clutter of `expect( $(...) )`.