### PR TITLE
Made changes to allow absolute urls to be used

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -154,6 +154,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   }
 
   jasmine.Fixtures.prototype.makeFixtureUrl_ = function (relativeUrl){
+    if (this.fixturesPath === '') {
+      return relativeUrl
+    }
     return this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
   }
 
@@ -220,6 +223,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     this.fixturesPath = 'spec/javascripts/fixtures/json'
   }
 
+  jasmine.JSONFixtures.prototype.makeFixtureUrl_ = jasmine.Fixtures.prototype.makeFixtureUrl_
+
   jasmine.JSONFixtures.prototype.load = function () {
     this.read.apply(this, arguments)
     return this.fixturesCache_
@@ -246,7 +251,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
   jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
     var self = this
-      , url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+      , url = this.makeFixtureUrl_(relativeUrl)
 
     $.ajax({
       async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded


### PR DESCRIPTION
I have been trying to answer some questions related to jasmine-jquery on stackoverfow using jsfiddle and one of the problems I have come up against is the ability to create relative urls on jsfiddle and also then in turn I can't use an absolute url as a alternative. Also I have included a change that allows Json Fixtures to make use of makeFixtureUrl_ as well.

The tests below all pass

// This test passes when not run in conjunction with the other tests below 
describe('The panel heading', function() {

    beforeEach(function() {
        loadStyleFixtures('panel.css');
        loadFixtures('panel.tmpl.html');
    });

    it('should have a color of white', function() {
      expect($('.panel-heading').css('color')).toEqual('rgb(255, 255, 255)');
    });

    it('should have a background-color of orange', function() {
      expect($('.panel-heading').css('background-color')).toEqual('rgb(221, 72, 20)');
    });

    it('should have a border-color of orange', function() {
      expect($('.panel-heading').css('border-color')).toEqual('rgb(221, 72, 20)');
    });
});

// These tests pass and run regardless of relative or absolute url

describe('The info button', function() {

    jasmine.getStyleFixtures().fixturesPath = '';
    jasmine.getFixtures().fixturesPath = '';

    beforeEach(function() {
        loadStyleFixtures('https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.css');
        loadFixtures('templates/single-button-dropdowns.tmpl.html');
    });

    it('should have a color of white', function() {
      expect($('.btn-primary').css('color')).toEqual('rgb(255, 255, 255)');
    });

    it('should have a background-color of blue', function() {
      expect($('.btn-primary').css('background-color')).toEqual('rgb(51, 122, 183)');
    });

    it('should have a border-color of blue', function() {
      expect($('.btn-primary').css('border-color')).toEqual('rgb(46, 109, 164)');
    });
});

jasmine.getJSONFixtures().fixturesPath = '';

describe('The employees json', function() {

    var data;

    beforeEach(function() {
      data = getJSONFixture('json/employees.json');
    });

    it('should have a firstname and lastname for an employee', function() {
      expect(data.employees[0].firstName.length > -1).toBe(true);
      expect(data.employees[0].lastName.length > -1).toBe(true);
    });
});

jasmine.getJSONFixtures().fixturesPath = '';

describe('The authors json', function() {

    var data;

    beforeEach(function() {
      data = getJSONFixture('https://api.myjson.com/bins/4ecud');
    });

    it('should have a firstname and lastname for an author', function() {
      expect(data.authors[0].firstName.length > -1).toBe(true);
      expect(data.authors[0].lastName.length > -1).toBe(true);
    });
});