### PR TITLE
correctly remove handlers from spyOnEvent

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -292,7 +292,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       $(selector).on(eventName, handler)
-      data.handlers.push(handler)
+      data.handlers.push({selector: selector,
+                          eventName: eventName,
+                          handler: handler})
 
       return {
         selector: selector,
@@ -355,6 +357,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     cleanUp: function () {
       data.spiedEvents = {}
+      $.each(data.handlers, function(index, o) {
+        $(o.selector).off(o.eventName, o.handler)
+      })
       data.handlers    = []
     }
   }

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -425,10 +425,10 @@ describe("jasmine.Fixtures using real AJAX call", function () {
       expect($("#anchor_01").length).toBe(1)
     })
   })
-  
+
   describe("When the fixture contains a HTML 5 style checked checkbox", function () {
 	var fixtureUrl = "fixture_with_checkbox_with_checked.html"
-	
+
 	it("Then the fixture is loaded successfully", function () {
 	  jasmine.getFixtures().load(fixtureUrl)
 	  expect('#' + jasmine.getFixtures().containerId).toContainElement('#checked-box')
@@ -1036,7 +1036,7 @@ describe("jQuery matcher", function () {
     beforeEach(function () {
       setFixtures(sandbox().html('<a id="clickme">Click Me</a> <a id="otherlink">Other Link</a>'))
       spyEvents['#clickme'] = spyOnEvent($('#clickme'), 'click')
-      spyOnEvent(document, 'click')
+      spyEvents[document] = spyOnEvent(document, 'click')
       spyOnEvent($('#otherlink'), 'click')
     })
 
@@ -1081,6 +1081,12 @@ describe("jQuery matcher", function () {
       $('#clickme').click()
       expect(spyEvents['#clickme'].calls.count()).toEqual(3);
       expect(spyEvents['#clickme'].calls.any()).toEqual(true);
+    })
+
+    it('should correctly track counts if the spy happened on document', function() {
+      expect(spyEvents[document].calls.count()).toEqual(0);
+      $(document).click()
+      expect(spyEvents[document].calls.count()).toEqual(1);
     })
   })
 


### PR DESCRIPTION
The previous code didn't remove the listeners, which was fine if the
selector was removed after the test.  For global selectors like
`document`, the handlers would never be removed.