### PR TITLE
added toBeDOMNodeOfType method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ jasmine-jquery provides the following custom matchers (in alphabetical order):
 - `toHaveValue(value)`
   - only for elements on which `val` can be called (`input`, `textarea`, etc)
   - e.g. `expect($('<input type="text" value="some text"/>')).toHaveValue('some text')`
+- `toBeDOMNodeOfType(string)`
+  - Checks to see if a DOM element is of a certain type
+  - e.g. `expect($('<input type="text" />]').toBeDOMNodeOfType('text')`
 
 The same as with standard Jasmine matchers, all of the above custom matchers may be inverted by using `.not` prefix, e.g.:
 

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -566,6 +566,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
       },
 
+      toBeDOMNodeOfType: function() {
+        return {
+          compare: function(actual, type) {
+            return { pass: $(actual).attr('type') === type }
+          }
+        }
+      },
+
       toBeFocused: function (selector) {
         return {
           compare: function (actual, selector) {


### PR DESCRIPTION
Added `toBeDOMNodeOfType` method to library. A simple method to return if an element is of a certain type; I found myself adding this method so I thought it might be useful for other developers.