### PR TITLE
updating toHaveCss() to account for cross-browser differences

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -385,11 +385,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       toHaveCss: function () {
         return {
           compare: function (actual, css) {
-            for (var prop in css){
+            var stripCharsRegex = /[\s;\"\']/g
+            for (var prop in css) {
               var value = css[prop]
               // see issue #147 on gh
-              ;if (value === 'auto' && $(actual).get(0).style[prop] === 'auto') continue
-              if ($(actual).css(prop) !== value) return { pass: false }
+              ;if ((value === 'auto') && ($(actual).get(0).style[prop] === 'auto')) continue
+              var actualStripped = $(actual).css(prop).replace(stripCharsRegex, '')
+              var valueStripped = value.replace(stripCharsRegex, '')
+              if (actualStripped !== valueStripped) return { pass: false }
             }
             return { pass: true }
           }

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -576,6 +576,30 @@ describe("jQuery matcher", function () {
       $("#sandbox").css("display", "none");
       expect($("#sandbox")).toHaveCss({height: 'auto', 'margin-left': "auto", display: "none"});
     })
+
+    it("should pass for string properties with quote characters (double quotes)", function() {
+      var fontFace = '"Courier New", monospace'; 
+      $("#sandbox").css("font-family", fontFace);
+      expect($("#sandbox")).toHaveCss({'font-family': fontFace});
+    })
+    
+    it("should pass for string properties with quote characters (single quotes)", function() {
+      var fontFace = "'Courier New', monospace";
+      $("#sandbox").css("font-family", fontFace);
+      expect($("#sandbox")).toHaveCss({'font-family': fontFace});
+    })
+
+    it("should pass for string and color properties (no quotes)", function() {
+      var fontFace = "Courier New, monospace";
+      $("#sandbox").css("font-family", fontFace);
+      expect($("#sandbox")).toHaveCss({'font-family': fontFace});
+    });
+    
+    it("should pass for string properties with no space", function() {
+      var fontFace = '"Courier New",monospace';
+      $("#sandbox").css("font-family", fontFace);
+      expect($("#sandbox")).toHaveCss({'font-family': fontFace});
+    })
   })
 
   describe("toHaveId", function () {


### PR DESCRIPTION
I am writing unit tests that check if inline styles are properly applied to a DOM element. One of the properties I'm applying is `font-family`, something like this: 

```css
<span style="'Courier New', monospace">Hello, world!</span>
```

However, calling `$('span').css('font-family')` can return different strings, depending on the browser. For example:
* Chrome/Safari/Phantom: `'Courier New', monospace` <= Single quotes, space after comma
* Firefox: `"Courier New",monospace` <= Double quotes, no space after comma

These slight string formatting differences cause the `toHaveCss()` matcher to fail when unit tests are run cross-browser. Instead of doing custom string comparison for all browsers, why not update `toHaveCss()` to ignore these formatting differences?

This PR includes an updated `toHaveCss()` matcher that runs a regex on the actual and expected CSS values for each property being matched. This regex strips spaces, quotes, and semicolons - characters that could get in the way of strings (that represent the same CSS) being unequal. Existing unit tests pass, and I added new tests to exercise this character stripping capability.

CodePen of tests before fix: http://codepen.io/bencentra/pen/MapmjJ
CodePen of fixed tests (with temporary `toHaveCssFixed()` matcher): http://codepen.io/bencentra/pen/JYWJzd

Tested on Chrome, Firefox, Safari, and Phantom on OS X. CodePens use Jasmine 2.3.4 and jasmine-jquery 2.1.1.