### PR TITLE
Fix toHandleWith()

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -621,6 +621,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             var normalizedEventName = eventName.split('.')[0]
               , stack = $._data($(actual).get(0), "events")[normalizedEventName]
 
+            if (!stack) {
+              return { pass: false }
+            }
+
             for (var i = 0; i < stack.length; i++) {
               if (stack[i].handler == eventHandler) return { pass: true }
             }

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -624,7 +624,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
             if (!events) return { pass: false };
 
-            stack = $._data($(actual).get(0), "events")[normalizedEventName]
+            stack = events[normalizedEventName]
 
             if (!stack) return { pass: false };
 

--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -619,11 +619,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           compare: function (actual, eventName, eventHandler) {
             if ( !actual || actual.length === 0 ) return { pass: false };
             var normalizedEventName = eventName.split('.')[0]
-              , stack = $._data($(actual).get(0), "events")[normalizedEventName]
+              , events = $._data($(actual).get(0), "events")
+              , stack
 
-            if (!stack) {
-              return { pass: false }
-            }
+            if (!events) return { pass: false };
+
+            stack = $._data($(actual).get(0), "events")[normalizedEventName]
+
+            if (!stack) return { pass: false };
 
             for (var i = 0; i < stack.length; i++) {
               if (stack[i].handler == eventHandler) return { pass: true }

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -1470,11 +1470,14 @@ describe("jQuery matcher", function () {
       expect($('#clickme').get(0)).not.toHandleWith("click.namespaced", aDifferentHandler)
     })
 
-    it('should pass if the namespaced event is not bound at all', function () {
+    it('should fail if there is no event bound at all', function () {
       var handler = function (){}
+      expect($('#clickme')).not.toHandleWith('click', handler)
+      expect($('#clickme')).not.toHandleWith('click.namespaced', handler)
+    })
 
+    it('should pass if the namespaced event is not bound at all', function () {
       expect($('#clickme')).not.toHandle("click.namespaced")
-      expect($('#clickme')).not.toHandleWith("click.namespaced", handler)
       expect($('#clickme').get(0)).not.toHandle("click.namespaced")
     })
 

--- a/spec/suites/jasmine-jquery-spec.js
+++ b/spec/suites/jasmine-jquery-spec.js
@@ -425,10 +425,10 @@ describe("jasmine.Fixtures using real AJAX call", function () {
       expect($("#anchor_01").length).toBe(1)
     })
   })
-  
+
   describe("When the fixture contains a HTML 5 style checked checkbox", function () {
 	var fixtureUrl = "fixture_with_checkbox_with_checked.html"
-	
+
 	it("Then the fixture is loaded successfully", function () {
 	  jasmine.getFixtures().load(fixtureUrl)
 	  expect('#' + jasmine.getFixtures().containerId).toContainElement('#checked-box')
@@ -578,11 +578,11 @@ describe("jQuery matcher", function () {
     })
 
     it("should pass for string properties with quote characters (double quotes)", function() {
-      var fontFace = '"Courier New", monospace'; 
+      var fontFace = '"Courier New", monospace';
       $("#sandbox").css("font-family", fontFace);
       expect($("#sandbox")).toHaveCss({'font-family': fontFace});
     })
-    
+
     it("should pass for string properties with quote characters (single quotes)", function() {
       var fontFace = "'Courier New', monospace";
       $("#sandbox").css("font-family", fontFace);
@@ -594,7 +594,7 @@ describe("jQuery matcher", function () {
       $("#sandbox").css("font-family", fontFace);
       expect($("#sandbox")).toHaveCss({'font-family': fontFace});
     });
-    
+
     it("should pass for string properties with no space", function() {
       var fontFace = '"Courier New",monospace';
       $("#sandbox").css("font-family", fontFace);
@@ -1471,7 +1471,10 @@ describe("jQuery matcher", function () {
     })
 
     it('should pass if the namespaced event is not bound at all', function () {
+      var handler = function (){}
+
       expect($('#clickme')).not.toHandle("click.namespaced")
+      expect($('#clickme')).not.toHandleWith("click.namespaced", handler)
       expect($('#clickme').get(0)).not.toHandle("click.namespaced")
     })
 
@@ -1495,7 +1498,6 @@ describe("jQuery matcher", function () {
     it('should not fail when actual is null', function (){
       expect(null).not.toHandleWith('click')
     })
-
   })
 })
 


### PR DESCRIPTION
When there's no event bound at all `not.toHandleWith()` will throw an error instead of passing. Example:

```JavaScript
expect(selector).not.toHandleWith('click', handler);
```

The same already works with `not.toHandle()`.