### PR TITLE
Explicitly use GET for loading fixtures

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -130,6 +130,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       , request = $.ajax({
         async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
         cache: false,
+        method: 'GET',
         url: url,
         dataType: 'html',
         success: function (data, status, $xhr) {
@@ -146,6 +147,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
             cache: false,
             dataType: 'script',
+            method: 'GET',
             url: $(this).attr('src'),
             success: function (data, status, $xhr) {
                 htmlText += '<script>' + $xhr.responseText + '</script>'
@@ -258,6 +260,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
       cache: false,
       dataType: 'json',
+      method: 'GET',
       url: url,
       success: function (data) {
         self.fixturesCache_[relativeUrl] = data


### PR DESCRIPTION
Add a `method: 'GET'` to every `$.ajax` call - this allows jasmine-jquery to use fixtures even when testing code that overrides the default request method for jQuery.

(That can be done via `$.ajaxSetup({ type: "POST" });`.)

What do you think?

If we want to support jquery < 1.9, I can change `method` to `type`..

Not sure how to test this..?
