### PR TITLE
Improves error messages for toHaveText and toContainElement matchers

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -512,11 +512,18 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             var actualText = $(actual).text()
             var trimmedText = $.trim(actualText)
 
+            var result;
             if (text && $.isFunction(text.test)) {
-              return { pass: text.test(actualText) || text.test(trimmedText) }
+              result = { pass: text.test(actualText) || text.test(trimmedText) }
             } else {
-              return { pass: (actualText == text || trimmedText == text) }
+              result = { pass: (actualText == text || trimmedText == text) }
             }
+
+            result.message = result.pass ?
+              "Expected element '" + $(actual).html() + "' not to have text " + text :
+              "Expected element '" + $(actual).html() + "' to have text " + text;
+
+            return result;
           }
         }
       },
@@ -554,7 +561,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       toContainElement: function () {
         return {
           compare: function (actual, selector) {
-            return { pass: $(actual).find(selector).length }
+            var result = { pass: $(actual).find(selector).length };
+
+            result.message = result.pass ?
+            "Expected element '" + $(actual).html() + "' not to have element " + selector :
+            "Expected element '" + $(actual).html() + "' to have element " + selector;
+
+            return result;
           }
         }
       },


### PR DESCRIPTION
Improves error messages for toHaveText and toContainElement matchers when expectation not met.

E.g.:
expect($('.page-title')).toHaveText('My header');

Expected ({ 0: HTMLNode, length: 1, prevObject: ({ 0: HTMLNode, context: HTMLNode, length: 1 }), context: HTMLNode, selector: '.page-title' }) to have text 'My header'.

Expected element '<h1 class="my-class">My heading</h1>' to have text My header