### PR TITLE
Added check of exports to allow successful execution in Electron

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -28,11 +28,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 (function (root, factory) {
-     if (typeof module !== 'undefined' && module.exports) {
-        factory(root, root.jasmine, require('jquery'));
-    } else {
-        factory(root, root.jasmine, root.jQuery);
-    }
+  if (typeof module !== 'undefined' && module.exports && typeof exports !== 'undefined') {
+    factory(root, root.jasmine, require('jquery'));
+  } else {
+    factory(root, root.jasmine, root.jQuery);
+  }
 }((function() {return this; })(), function (window, jasmine, $) { "use strict";
 
   jasmine.spiedEventsKey = function (selector, eventName) {


### PR DESCRIPTION
Ran into [this issue](https://github.com/jasmine/jasmine/issues/964) in Jasmine. Jasmine has merged it but hasn't release it yet. So, I fixed it in my local copy and proceeded to add Jasmine-jQuery.

Lo and behold, Jasmine-jQuery had the same issue. In fact, it looked like the offending code had been cut from Jasmine and pasted into Jasmine-jQuery. Nothing wrong with that, of course. So, I made the same change to my local and it worked. So, I'm sharing the love and passing it on.

I didn't write any additional tests because, frankly, I don't see an easy way that I could. It appears that the user who added the code I am modifying also didn't write any so this probably isn't a big deal. I did, however, actually _run_ them. So, at least there's that.

I also cleaned up the function from a spacing point of view. The rest of the codebase and the contributing guidelines say '2 spaces'. This bit had four and to first line actually had a stray extra space. Five, as they say, is right out.
