### PR TITLE
Don't use the deprecated .selector method

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -36,7 +36,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 }((function() {return this; })(), function (window, jasmine, $) { "use strict";
 
   jasmine.spiedEventsKey = function (selector, eventName) {
-    return [$(selector).selector, eventName].toString()
+    for(var i = 0;; i++) {
+      var key = [eventName, i].toString()
+      if (data.spiedEvents[key] === undefined || data.spiedEvents[key].selector.is($(selector))) {
+        return key
+      }
+    }
   }
 
   jasmine.getFixtures = function () {
@@ -292,6 +297,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       var handler = function (e) {
         var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
         data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+          selector: $(selector),
           args: jasmine.util.argsToArray(arguments),
           calls: ++calls
         }


### PR DESCRIPTION
Method ".selector" of jQuery selector has been removed from
jQuery 3 [1].

At [1] it is said:
"These properties were deprecated in jQuery 1.9, as they were
only used for the obsolete .live() method and have never accurately
represented the context or selector for the current collection."

In this patch instead of using selector based indexing of the set of spies,
we save a selector object for each spy and then check if passed
selector matches the saved one using the ".is" jQuery method [2]. This way we
find a matching spy among the set of spies.

This patch improves support of jQuery v3 by jasmine-jquery.

[1] https://jquery.com/upgrade-guide/3.0/#breaking-change-deprecated-context-and-selector-properties-removed
[2] https://api.jquery.com/is/