### PR TITLE
add logic to retry ajax requests up to 3 times

### DIFF
--- a/lib/jasmine-jquery.js
+++ b/lib/jasmine-jquery.js
@@ -259,10 +259,18 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       cache: false,
       dataType: 'json',
       url: url,
+      tryCount: 0,
+      retryLimit: 3,
       success: function (data) {
         self.fixturesCache_[relativeUrl] = data
       },
       error: function ($xhr, status, err) {
+        this.tryCount++;
+        if (this.tryCount <= this.retryLimit) {
+          //try again
+          $.ajax(this)
+          return
+        }
         throw new Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
       }
     })


### PR DESCRIPTION
As the number of tests in our suite grow, we are starting to see frequent, but intermittent failures when loading JSON fixtures:

`Error: JSONFixture could not be loaded: test/sample-data-files/application-list.json (status: error, message: undefined) thrown`

Some retry logic on the jquery ajax requests has helped reduce this problem.